### PR TITLE
Update libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ dgedi.o:	dgedi.f
 	$(CC) -c $<
 
 clean:
-	-/bin/rm -f *.{o,mod,x,il,a} checkpoint_{field,main}.* makefile.dep
+	-/bin/rm -f *.{o,mod,x,il,a} *__genmod.f90 checkpoint_{field,main}.* makefile.dep
 
 makefile.dep: $(shell echo *.f90)
 	./make-depend.sh $^ > $@

--- a/README.rst
+++ b/README.rst
@@ -8,18 +8,20 @@ Libraries
 ---------
 Fortran libraries by Serguei Patchkovskii (MBI), Michael Spanner (NRC)
 and Sergei N. Yurchenko (UCL):
-    - accuracy.f90
-    - atoms.f90
-    - dgedi.f
-    - dgefa.f
-    - gamess_internal.f90
-    - import_gamess*.f90
-    - lapack.f90
-    - lebedev.f90
-    - math.f90
-    - molecular_grid.f90
-    - os_integral_operators.f90
-    - timer.f90
+
+- accuracy.f90
+- atoms.f90
+- dgedi.f
+- dgefa.f
+- gamess_internal.f90
+- import_gamess*.f90
+- lapack.f90
+- lebedev.f90
+- math.f90
+- molecular_grid.f90
+- os_integral_operators.f90
+- timer.f90
 
 Fortran library by Simon Neville (NRC):
-    - molden.f90
+
+- molden.f90

--- a/README.rst
+++ b/README.rst
@@ -4,5 +4,22 @@ Partitioning schemes for molecular electron densities.
 
 Created 2018 -- Ryan J. MacDonell and Michael S. Schuurman (uOttawa, NRC)
 
-Based on Fortran libraries by Serguei Patchkovskii (MBI), Michael Spanner (NRC)
-and Sergei N. Yurchenko (UCL).
+Libraries
+---------
+Fortran libraries by Serguei Patchkovskii (MBI), Michael Spanner (NRC)
+and Sergei N. Yurchenko (UCL):
+    - accuracy.f90
+    - atoms.f90
+    - dgedi.f
+    - dgefa.f
+    - gamess_internal.f90
+    - import_gamess*.f90
+    - lapack.f90
+    - lebedev.f90
+    - math.f90
+    - molecular_grid.f90
+    - os_integral_operators.f90
+    - timer.f90
+
+Fortran library by Simon Neville (NRC):
+    - molden.f90

--- a/accuracy.f90
+++ b/accuracy.f90
@@ -4,10 +4,12 @@ module accuracy
 !
   implicit none
   private
-  public sik, ik, hik, srk, drk, rk, ark, input, out, safe_max, max_exp, pi, twopi, fourpi, sqrtpi
+  public sik, ik, hik, srk, drk, qrk, rk, ark, xrk, input, out, safe_max, max_exp, pi, twopi, fourpi, sqrtpi
+  public pi_xrk
   public sqrt2pi, femtosecond, abohr, h2ev, h2cm, k_Boltzmann, Hartree, bar, vlight
   public R_gas, N_Avogadro, unified_atomic_mass_unit, electron_mass_in_amu, au2wcm2
-  public sik_bytes, ik_bytes, hik_bytes, rk_bytes, ark_bytes
+  public sik_bytes, ik_bytes, hik_bytes, rk_bytes, ark_bytes, xrk_bytes
+  public clen, au2tesla, gfactor
   public accuracyInitialize
 !
   integer, parameter :: sik         = selected_int_kind(4)       ! Small integers
@@ -16,17 +18,42 @@ module accuracy
                                                                  ! work correctly.
   integer, parameter :: hik         = selected_int_kind(15)      ! "Pointer" integers - sufficient to store
                                                                  ! memory address
+  !
+  !  srk, drk, and qrk are intended for communication with host libraries.
+  !  We use generic interfaces to pick the right library routine; this is
+  !  not the most elegant solution, but it is easy to use.
+  !
   integer, parameter :: srk         = kind(1.)                   ! Default real kind
   integer, parameter :: drk         = kind(1.d0)                 ! Double-precision real kind
+
+  integer, parameter :: qrk      = kind(1.d0)                 ! Dummy value, in case quad-precision does not exist
+
+!*qd integer, parameter :: qrk      = kind(1.q0)                 ! Quad-precision real kind
+!*nq integer, parameter :: qrk      = kind(1.d0)                 ! Dummy value, in case quad-precision does not exist
+  !
+  !  rk, ark, and xrk are intended for use within the code; they can be adjusted to fit
+  !  the circumstances.
+  !
   integer, parameter :: rk          = selected_real_kind(14,17)  ! "Normal" reals and complex (complexi? :-)
   integer, parameter :: ark         = selected_real_kind(14,17)  ! "Accurate" reals and complex (complexi? :-)
+                                                                 ! In practice, a lot of code treats rk and ark
+                                                                 ! as interchangeabge; be prepared to fix a lot
+                                                                 ! of bugs if they are not the same!
+  integer, parameter :: xrk         = ark                        ! "Highly-accurate" reals and complex
+!*qd  integer, parameter :: xrk         = selected_real_kind(28,50)  ! "Highly-accurate" reals and complex
+!*nq  integer, parameter :: xrk         = ark                        ! "Highly-accurate" reals and complex
+                                                                 ! At least one of the lines above must be activated!
   integer, parameter :: input       = 5                          ! Standard input I/O channel
   integer, parameter :: out         = 6                          ! Output I/O channel
+
+  integer, parameter :: clen        = 100                        ! Standard character length; enough for most
+                                                                 ! keywords and file names
 
   real(rk)           :: safe_max                                 ! Largest number we want to work with
   real(rk)           :: max_exp                                  ! Largest number OK for exponentiating
   real(rk)           :: pi, twopi, fourpi, sqrtpi, sqrt2pi       ! Pi, 2*Pi, 4*Pi, SQRT(2*Pi)
-  integer(ik)        :: sik_bytes, ik_bytes, hik_bytes, rk_bytes, ark_bytes
+  integer(ik)        :: sik_bytes, ik_bytes, hik_bytes, rk_bytes, ark_bytes, xrk_bytes
+  real(xrk), parameter :: pi_xrk      = 3.1415926535897932384626433832795028841972_xrk ! pi, of course
   !
   !  Physical constants - must be here to guarantee consistency
   !
@@ -45,6 +72,8 @@ module accuracy
   real(ark), parameter :: electron_mass_in_amu     = 5.4857990943e-4_ark ! Electron mass in u-amu
   real(ark), parameter :: au2wcm2     = 3.5e16_ark               ! Conversion factor: from square of peak intensity (linear polarization)
                                                                  !                    to cycle-average intensity in W/cm^2
+  real(rk), parameter  :: au2tesla = 2.350517382e5_rk            ! Conversion factor from "zeeman" to SI Tesla
+  real(rk), parameter  :: gfactor  = 2.0023193043622_rk          ! Electron g-factor
   !
   contains
 
@@ -64,8 +93,9 @@ module accuracy
     hik_bytes = int_bytes(radix(1_hik),digits(1_hik))
     rk_bytes  = real_bytes(radix(1._rk) ,digits(1._rk ),maxexponent(1._rk )-minexponent(1._rk ))
     ark_bytes = real_bytes(radix(1._ark),digits(1._ark),maxexponent(1._ark)-minexponent(1._ark))
+    xrk_bytes = real_bytes(radix(1._xrk),digits(1._xrk),maxexponent(1._xrk)-minexponent(1._xrk))
     write (out,"('Compiled integer sizes: ',3(i4,1x),' bytes')") sik_bytes, ik_bytes, hik_bytes
-    write (out,"('Compiled real sizes: ',2(i4,1x),' bytes')") rk_bytes, ark_bytes
+    write (out,"('Compiled real sizes: ',3(i4,1x),' bytes')") rk_bytes, ark_bytes, xrk_bytes
   end subroutine accuracyInitialize
 
   integer(ik) function int_bytes(radix,digits)

--- a/atoms.f90
+++ b/atoms.f90
@@ -141,8 +141,6 @@
       character(len=*), intent(in) :: atom ! Element symbol
       real(rk)                     :: q    ! Nuclear charge, in |e| units
       !
-      integer(ik) :: ind
-      !
       q = find_atom(atom)
     end function AtomNuclearCharge
     !
@@ -167,7 +165,7 @@
       integer(ik)                  :: ind  ! Index in elements, or -1 if not found
       !
       character(len=3) :: la
-      integer          :: ia
+      integer          :: ia    ! Must be of default integer kind - iachar has problems otherwise
       !
       la = atom
       !

--- a/bader.f90
+++ b/bader.f90
@@ -151,7 +151,7 @@ program bader
     adone(:,:) = .false.
     first_shell = .true.
     last = .false.
-    iat = den_grid%iatom
+    iat = den_grid%next_part
     mol_grid_batches: do ib = 1,nbatch-1
         if (first_shell) then
             ! get next grid points
@@ -167,7 +167,7 @@ program bader
                 ! get next grid points
                 call GridPointsBatch(den_grid, 'Next batch', xyzw=xyzw_nxt)
                 ! check to see if the next shell is a different atom
-                if (iat /= den_grid%iatom) then
+                if (iat /= den_grid%next_part) then
                     ls = .true.
                 else
                     ls = .false.
@@ -198,7 +198,7 @@ program bader
             asgn(2,:) = 0
             adone(1,:) = adone(2,:)
             adone(2,:) = .false.
-            iat = den_grid%iatom
+            iat = den_grid%next_part
             if (ls) then
                 first_shell = .true.
             end if

--- a/gamess_internal.f90
+++ b/gamess_internal.f90
@@ -1,4 +1,6 @@
 !
+!  2016 Sept 14 - Extended to support H and I orbitals (L=5,6)
+!
 !  Internal definitions needed for working directly with GAMESS orbitals
 !  and data files. This module is tightly coupled to import_gamess and
 !  ecp_gamess. It should not be directly relied upon by anything else.
@@ -16,69 +18,108 @@
    use accuracy
    implicit none
    public
+   private a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q
    !
-    integer(ik), parameter :: gam_file            = 57    ! A semi-randomly chosen unit
-    integer(ik), parameter :: gam_max_line        = 192
-    integer(ik), parameter :: gam_max_shells      = 600
-    integer(ik), parameter :: gam_max_ecp_terms   = 100
-    integer(ik), parameter :: gam_max_primitive   = 2000
-    integer(ik), parameter :: gam_max_atoms       = 1000
-    integer(ik), parameter :: gam_max_contraction = 50
-    integer(ik), parameter :: gam_max_batch_size  = 60 ! Split up very long batches; otherwise, memory requirements 
-                                                       ! become -very- large
-    integer(ik), parameter :: gam_orbcnt(0:4)   = (/ 1, 3, 6, 10, 15 /)
-    real(xrk), parameter   :: gam_normc (0:4)   = (/ 1._xrk, 1._xrk/2._xrk, 3._xrk/4._xrk, 15._xrk/8._xrk, 105._xrk/16._xrk /)
+    integer(ik), parameter :: gam_file               = 57    ! A semi-randomly chosen unit
+    integer(ik), parameter :: gam_max_line           = 192
+    integer(ik), parameter :: gam_max_shells         = 600
+    integer(ik), parameter :: gam_max_ecp_terms      = 100
+    integer(ik), parameter :: gam_max_primitive      = 2000
+    integer(ik), parameter :: gam_max_atoms          = 1000
+    integer(ik), parameter :: gam_max_contraction    = 50
+    integer(ik), parameter :: gam_max_batch_size     = 60 ! Split up very long batches; otherwise, memory requirements
+                                                          ! become -very- large
+    !
+    integer(ik), parameter :: gam_lmax               = 6  ! Highest angular momentum
+    integer(ik), parameter :: gam_nxyz               = 84 ! Number of possible XYZ products
+    ! orbcnt(l) = (l+1)*(l+2)/2
+    integer(ik), parameter :: gam_orbcnt(0:gam_lmax) = (/ 1, 3, 6, 10, 15, 21, 28 /)
+    ! normc(l)  = Gamma[l+1/2] / sqrt(pi) = (2l-1)!!/2**l
+    real(xrk), parameter   :: gam_normc (0:gam_lmax) = (/ 1._xrk, 1._xrk/2._xrk, 3._xrk/4._xrk, 15._xrk/8._xrk, 105._xrk/16._xrk, &
+                                                          945._xrk/32._xrk, 10395._xrk/64._xrk /)
     !
     !  Definition of the angular parts of GAMESS basis functions
-    ! 
-    real(xrk), parameter   :: a = 1.7320508075688772935274463415058723669428_xrk ! sqrt( 3.0)
-    real(xrk), parameter   :: b = 2.2360679774997896964091736687312762354406_xrk ! sqrt( 5.0)
-    real(xrk), parameter   :: c = 3.8729833462074168851792653997823996108329_xrk ! sqrt(15.0)
-    real(xrk), parameter   :: d = 2.6457513110645905905016157536392604257102_xrk ! sqrt( 7.0)
-    real(xrk), parameter   :: e = 3.4156502553198661277403462268403506635783_xrk ! sqrt(35.0/3.0)
-    real(xrk), parameter   :: f = 5.9160797830996160425673282915616170484155_xrk ! sqrt(35.0)
-    real(xrk), parameter   :: o = 1._xrk
-    integer(ik), parameter :: ang_loc(0:5) = (/ 0, 1, 4, 10, 20, 35 /)
-                                             !                      1                   2                   3
-                                             !  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
-                                             !                                          X Y Z X X Y Y Z Z X X Y X Y Z
-                                             !                      X Y Z X X Y Y Z Z X X Y Z X X Y Y Z Z X X Y X Y Z
-                                             !          X Y Z X X Y X Y Z X X Y Y Z Z Y X Y Z X X Y Y Z Z Y Z Z Y X X
-                                             !  S X Y Z X Y Z Y Z Z X Y Z Y Z X Z X Y Z X Y Z Y Z X Z X Y Y Z Z Z Z Y
-    integer(ik), parameter :: ang_nx(0:34) = (/ 0,1,0,0,2,0,0,1,1,0,3,0,0,2,2,1,0,1,0,1,4,0,0,3,3,1,0,1,0,2,2,0,2,1,1/)
-    integer(ik), parameter :: ang_ny(0:34) = (/ 0,0,1,0,0,2,0,1,0,1,0,3,0,1,0,2,2,0,1,1,0,4,0,1,0,3,3,0,1,2,0,2,1,2,1/)
-    integer(ik), parameter :: ang_nz(0:34) = (/ 0,0,0,1,0,0,2,0,1,1,0,0,3,0,1,0,1,2,2,1,0,0,4,0,1,0,1,3,3,0,2,2,1,1,2/)
-    real(xrk), parameter   :: ang_c (0:34) = (/ o,o,o,o,o,o,o,a,a,a,o,o,o,b,b,b,b,b,b,c,o,o,o,d,d,d,d,d,d,e,e,e,f,f,f/)
-    real(rk), parameter    :: ang_c_rk(0:34) = real( &
-                                             (/ o,o,o,o,o,o,o,a,a,a,o,o,o,b,b,b,b,b,b,c,o,o,o,d,d,d,d,d,d,e,e,e,f,f,f/), &
-                                               kind=rk)
-    integer(ik), parameter :: ang_nxyz(0:34,3) = reshape((/ang_nx,ang_ny,ang_nz/),(/35,3/))
     !
-    character(len=1), parameter :: shell_name(0:4) = (/ 'S', 'P', 'D', 'F', 'G' /)
-    character(len=4), parameter :: ang_name(0:34) = (/ &
-        ' S  ', &
-        ' X  ', ' Y  ', ' Z  ', &
-        'XX  ', 'YY  ', 'ZZ  ', 'XY  ', 'XZ  ', 'YZ  ', &
-        'XXX ', 'YYY ', 'ZZZ ', 'XXY ', 'XXZ ', 'YYX ', 'YYZ ', 'ZZX ', 'ZZY ', 'XYZ ', &
-        'XXXX', 'YYYY', 'ZZZZ', 'XXXY', 'XXXZ', 'YYYX', 'YYYZ', 'ZZZX', 'ZZZY', 'XXYY', 'XXZZ', 'YYZZ', 'XXYZ', 'YYXZ', 'ZZXY' /)
+    real(xrk), parameter   :: a = 1.73205080756887729352744634150587236694281_xrk ! sqrt( 3.0)
+    real(xrk), parameter   :: b = 2.23606797749978969640917366873127623544062_xrk ! sqrt( 5.0)
+    real(xrk), parameter   :: c = 3.87298334620741688517926539978239961083292_xrk ! sqrt(15.0)
+    real(xrk), parameter   :: d = 2.64575131106459059050161575363926042571026_xrk ! sqrt( 7.0)
+    real(xrk), parameter   :: e = 3.41565025531986612774034622684035066357834_xrk ! sqrt(35.0/3.0)
+    real(xrk), parameter   :: f = 5.91607978309961604256732829156161704841550_xrk ! sqrt(35.0)
+    real(xrk), parameter   :: g = 3.00000000000000000000000000000000000000000_xrk !
+    real(xrk), parameter   :: h = 4.58257569495584000658804719372800848898446_xrk !
+    real(xrk), parameter   :: i = 7.93725393319377177150484726091778127713078_xrk !
+    real(xrk), parameter   :: j = 10.2469507659595983832210386805210519907350_xrk !
+    real(xrk), parameter   :: k = 3.31662479035539984911493273667068668392709_xrk !
+    real(xrk), parameter   :: l = 5.74456264653802865985061146821892931822026_xrk !
+    real(xrk), parameter   :: m = 9.94987437106619954734479821001206005178127_xrk !
+    real(xrk), parameter   :: n = 6.79705818718657137846900052738478763345227_xrk !
+    real(xrk), parameter   :: o = 1.00000000000000000000000000000000000000000_xrk !
+    real(xrk), parameter   :: p = 15.1986841535706636316687442060396450375823_xrk !
+    real(xrk), parameter   :: q = 19.6214168703485834685260037891817743263128_xrk !
     !
-    !  The "drop_?" arrays make it easier to construct Obara-Saika recurrences 
+    ! ang_loc(l) = sum(gam_orbcnt(0:l-1))
+    integer(ik), parameter :: ang_loc(0:gam_lmax+1) = (/ 0, 1, 4, 10, 20, 35, 56, 84 /)
+    ! ang_n? defines function ordering. Ad hoc, so be careful with the table!
+                                                     !                      1                   2                   3
+                                                     !  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
+                                                     !                                          X Y Z X X Y Y Z Z X X Y X Y Z
+                                                     !                      X Y Z X X Y Y Z Z X X Y Z X X Y Y Z Z X X Y X Y Z
+                                                     !          X Y Z X X Y X Y Z X X Y Y Z Z Y X Y Z X X Y Y Z Z Y Z Z Y X X
+                                                     !  S X Y Z X Y Z Y Z Z X Y Z Y Z X Z X Y Z X Y Z Y Z X Z X Y Y Z Z Z Z Y
+    integer(ik), parameter :: ang_nx(0:gam_nxyz-1) = (/ 0,1,0,0,2,0,0,1,1,0,3,0,0,2,2,1,0,1,0,1,4,0,0,3,3,1,0,1,0,2,2,0,2,1,1, &
+                                                        5,0,0,4,4,1,0,1,0,3,3,2,0,2,0,3,1,1,2,2,1, &
+                                                        6,0,0,5,5,1,0,1,0,4,4,2,0,2,0,4,1,1,3,3,0,3,3,2,1,2,1,2/)
+    integer(ik), parameter :: ang_ny(0:gam_nxyz-1) = (/ 0,0,1,0,0,2,0,1,0,1,0,3,0,1,0,2,2,0,1,1,0,4,0,1,0,3,3,0,1,2,0,2,1,2,1, &
+                                                        0,5,0,1,0,4,4,0,1,2,0,3,3,0,2,1,3,1,2,1,2, &
+                                                        0,6,0,1,0,5,5,0,1,2,0,4,4,0,2,1,4,1,3,0,3,2,1,3,3,1,2,2 /)
+    integer(ik), parameter :: ang_nz(0:gam_nxyz-1) = (/ 0,0,0,1,0,0,2,0,1,1,0,0,3,0,1,0,1,2,2,1,0,0,4,0,1,0,1,3,3,0,2,2,1,1,2, &
+                                                        0,0,5,0,1,0,1,4,4,0,2,0,2,3,3,1,1,3,1,2,2, &
+                                                        0,0,6,0,1,0,1,5,5,0,2,0,2,4,4,1,1,4,0,3,3,1,2,1,2,3,3,2 /)
+    real(xrk), parameter   :: ang_c (0:gam_nxyz-1) = (/ o,o,o,o,o,o,o,a,a,a,o,o,o,b,b,b,b,b,b,c,o,o,o,d,d,d,d,d,d,e,e,e,f,f,f, &
+                                                        o,o,o,g,g,g,g,g,g,h,h,h,h,h,h,i,i,i,j,j,j, &
+                                                        o,o,o,k,k,k,k,k,k,l,l,l,l,l,l,m,m,m,n,n,n,p,p,p,p,p,p,q /)
+    real(rk), parameter    :: ang_c_rk(0:gam_nxyz-1) = real(ang_c,kind=rk)
+    integer(ik), parameter :: ang_nxyz(0:gam_nxyz-1,3) = reshape((/ang_nx,ang_ny,ang_nz/),(/gam_nxyz,3/))
+    !
+    character(len=1), parameter :: shell_name(0:gam_lmax) = (/ 'S', 'P', 'D', 'F', 'G', 'H', 'I' /)
+    character(len=6), parameter :: ang_name(0:gam_nxyz-1) = (/ &
+        ' S    ', &
+        ' X    ', ' Y    ', ' Z    ', &
+        'XX    ', 'YY    ', 'ZZ    ', 'XY    ', 'XZ    ', 'YZ    ', &
+        'XXX   ', 'YYY   ', 'ZZZ   ', 'XXY   ', 'XXZ   ', 'YYX   ', 'YYZ   ', 'ZZX   ', 'ZZY   ', 'XYZ   ', &
+        'XXXX  ', 'YYYY  ', 'ZZZZ  ', 'XXXY  ', 'XXXZ  ', 'YYYX  ', 'YYYZ  ', 'ZZZX  ', 'ZZZY  ', 'XXYY  ', &
+        'XXZZ  ', 'YYZZ  ', 'XXYZ  ', 'YYXZ  ', 'ZZXY  ', &
+        'X5    ', 'Y5    ', 'Z5    ', 'X4Y   ', 'X4Z   ', 'Y4X   ', 'Y4Z   ', 'Z4X   ', 'Z4Y   ', 'X3Y2  ', &
+        'X3Z2  ', 'Y3X2  ', 'Y3Z2  ', 'Z3X2  ', 'Z3Y2  ', 'X3YZ  ', 'Y3XZ  ', 'Z3XY  ', 'X2Y2Z ', 'X2Z2Y ', &
+        'Y2Z2X ',  &
+        'X6    ', 'Y6    ', 'Z6    ', 'X5Y   ', 'X5Z   ', 'Y5X   ', 'Y5Z   ', 'Z5X   ', 'Z5Y   ', 'X4Y2  ', &
+        'X4Z2  ', 'Y4X2  ', 'Y4Z2  ', 'Z4X2  ', 'Z4Y2  ', 'X4YZ  ', 'Y4XZ  ', 'Z4XY  ', 'X3Y3  ', 'X3Z3  ', &
+        'Y3Z3  ', 'X3Y2Z ', 'X3Z2Y ', 'Y3X2Z ', 'Y3Z2X ', 'Z3X2Y ', 'Z3Y2X ', 'X2Y2Z2' /)
+    !
+    !  The "drop_?" arrays make it easier to construct Obara-Saika recurrences
     !  for the integrals. One could also compute drop tables on the fly from the
     !  ang_?? tables - however, having them as a parameter lets the compiler to
     !  unroll recurrence loops and convert them to optimal data flow graphs.
-          !                                 1                             2                             3              
+          !                                 1                             2                             3
           !   0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5  6  7  8  9  0  1  2  3  4
           !                                                               X  Y  Z  X  X  Y  Y  Z  Z  X  X  Y  X  Y  Z
           !                                 X  Y  Z  X  X  Y  Y  Z  Z  X  X  Y  Z  X  X  Y  Y  Z  Z  X  X  Y  X  Y  Z
           !               X  Y  Z  X  X  Y  X  Y  Z  X  X  Y  Y  Z  Z  Y  X  Y  Z  X  X  Y  Y  Z  Z  Y  Z  Z  Y  X  X
           !   S  X  Y  Z  X  Y  Z  Y  Z  Z  X  Y  Z  Y  Z  X  Z  X  Y  Z  X  Y  Z  Y  Z  X  Z  X  Y  Y  Z  Z  Z  Z  Y
-    integer(ik), parameter :: drop_x(0:34) = &
-          (/ -1, 0,-1,-1, 1,-1,-1, 2, 3,-1, 4,-1,-1, 7, 8, 5,-1, 6,-1, 9,10,-1,-1,13,14,11,-1,12,-1,15,17,-1,19,16,18 /)
-    integer(ik), parameter :: drop_y(0:34) = &
-          (/ -1,-1, 0,-1,-1, 2,-1, 1,-1, 3,-1, 5,-1, 4,-1, 7, 9,-1, 6, 8,-1,11,-1,10,-1,15,16,-1,12,13,-1,18,14,19,17 /)
-    integer(ik), parameter :: drop_z(0:34) = &
-          (/ -1,-1,-1, 0,-1,-1, 3,-1, 1, 2,-1,-1, 6,-1, 4,-1, 5, 8, 9, 7,-1,-1,12,-1,10,-1,11,17,18,-1,14,16,13,15,19 /)
-    integer(ik), parameter :: drop_xyz(0:34,3) = reshape((/drop_x,drop_y,drop_z/),(/35,3/))
+    integer(ik), parameter :: drop_x(0:gam_nxyz-1) = &
+          (/ -1, 0,-1,-1, 1,-1,-1, 2, 3,-1, 4,-1,-1, 7, 8, 5,-1, 6,-1, 9,10,-1,-1,13,14,11,-1,12,-1,15,17,-1,19,16,18, &
+             20,-1,-1,23,24,21,-1,22,-1,29,30,25,-1,27,-1,32,26,28,33,34,31,35,-1,-1,38,39,36,-1,37,-1,44,45,40,-1,42, &
+             -1,50,41,43,46,48,-1,53,54,51,47,52,49,55 /)
+    integer(ik), parameter :: drop_y(0:gam_nxyz-1) = &
+          (/ -1,-1, 0,-1,-1, 2,-1, 1,-1, 3,-1, 5,-1, 4,-1, 7, 9,-1, 6, 8,-1,11,-1,10,-1,15,16,-1,12,13,-1,18,14,19,17, &
+             -1,21,-1,20,-1,25,26,-1,22,23,-1,29,31,-1,28,24,33,27,32,30,34,-1,36,-1,35,-1,40,41,-1,37,38,-1,46,47,-1, &
+             43,39,51,42,44,-1,49,50,45,53,55,48,52,54 /)
+    integer(ik), parameter :: drop_z(0:gam_nxyz-1) = &
+          (/ -1,-1,-1, 0,-1,-1, 3,-1, 1, 2,-1,-1, 6,-1, 4,-1, 5, 8, 9, 7,-1,-1,12,-1,10,-1,11,17,18,-1,14,16,13,15,19, &
+             -1,-1,22,-1,20,-1,21,27,28,-1,24,-1,26,30,31,23,25,34,29,32,33,-1,-1,37,-1,35,-1,36,42,43,-1,39,-1,41,48, &
+             49,38,40,52,-1,45,47,44,50,46,51,54,55,53 /)
+    integer(ik), parameter :: drop_xyz(0:gam_nxyz-1,3) = reshape((/drop_x,drop_y,drop_z/),(/gam_nxyz,3/))
     !
     type gam_atom
       character(len=20)    :: name                         ! Name of the atom
@@ -112,7 +153,7 @@
       integer(ik)                    :: nbasis   = 0          ! Number of Cartesian basis functions
       integer(ik)                    :: nvectors = 0          ! Number of vectors in this set
       type(gam_atom), allocatable    :: atoms(:)              ! Table of atoms
-      character(len=11), allocatable :: bas_labels(:)         ! Basis labels
+      character(len=13), allocatable :: bas_labels(:)         ! Basis labels
       real(rk), allocatable          :: vectors(:,:)          ! Molecular orbitals
       real(xrk)                      :: rotmat(3,3)           ! Rotation matrix for this structure
       real(rk)                       :: rotmat_rk(3,3)        ! ditto, standard precision
@@ -123,7 +164,7 @@
       !
       integer(ik)                    :: nbatches   = 0        ! Number of batches in this structure
                                                               ! Consecuitive shells with the same L will be grouped
-                                                              ! into the same batch - this dramatically improves 
+                                                              ! into the same batch - this dramatically improves
                                                               ! utilization of primitive integrals for contracted basis sets.
       integer(ik)                    :: max_shells = 0        ! Number of shells in the largest batch
       integer(ik)                    :: max_batch  = 0        ! Number of orbitals in the largest batch
@@ -189,7 +230,7 @@
         label_shells: do ish=1,gam%atoms(iat)%nshell
           ish_l = gam%atoms(iat)%sh_l(ish)
           label_functions: do im=ang_loc(ish_l),ang_loc(ish_l+1)-1
-            write (gam%bas_labels(ip),"(1x,a2,i3,1x,a4)") gam%atoms(iat)%name(1:2), iat, ang_name(im)
+            write (gam%bas_labels(ip),"(1x,a2,i3,1x,a6)") gam%atoms(iat)%name(1:2), iat, ang_name(im)
             ip = ip + 1
           end do label_functions
         end do label_shells
@@ -227,7 +268,7 @@
       !  Orbitals section (if allocated)
       !
       if (allocated(gam%vectors)) then
-        write (iu,"(' $VEC')") 
+        write (iu,"(' $VEC')")
         print_vectors: do ivec=1,gam%nvectors
           call punch_vector(iu,ivec,gam%vectors(:,ivec))
         end do print_vectors

--- a/gridchg.f90
+++ b/gridchg.f90
@@ -90,7 +90,7 @@ program gridchg
         open(mfile, file='moldens', form='unformatted', action='write')
         open(pfile, file='dens.mol', action='write')
         norm = 0_rk
-        nullify(xyzw)
+        !nullify(xyzw)
         mol_grid_batches: do ib = 1,nbatch
             !
             !  Get grid points
@@ -112,8 +112,8 @@ program gridchg
             !
             !  Integrate and save
             !
+            norm = norm + sum(xyzw(4,:) * rhomol)
             mol_integrate: do ipt = 1,npts
-                norm = norm + xyzw(4,ipt) * rhomol(ipt)
                 write(mfile) rhomol(ipt)
                 write(pfile,1000) xyzw(4,ipt), xyzw(1:3,ipt), rhomol(ipt)
             end do mol_integrate
@@ -167,14 +167,14 @@ program gridchg
         call update_atoms(charge, inp%max_charge, qlist, natom, iwhr, nuniq, inp%n_rad_atom, inp%atom_lib, inp%atom_type, aload, ax, aw, acden, aden)
         !call update_densmat(charge, inp%max_charge, qlist, natom, iwhr, nuniq, dload, npbas, pdens)
         call GridPointsBatch(den_grid, 'Reset')
-        iat = den_grid%iatom
+        iat = den_grid%next_part
         normatm = 0_rk
         dcharge = 0_rk
-        nullify(xyzw)
         grid_batches: do ib = 1,nbatch
             !
             !  Get grid points
             !
+            nullify(xyzw)
             call GridPointsBatch(den_grid, 'Next batch', xyzw=xyzw)
             !
             !  If the batch size changed, reallocate density and weight arrays
@@ -226,7 +226,7 @@ program gridchg
                 end do integrate_pop
             end if
             ! get iatom for the next shell
-            iat = den_grid%iatom
+            iat = den_grid%next_part
         end do grid_batches
         close(qfile)
         close(wfile)

--- a/gridchg.f90
+++ b/gridchg.f90
@@ -90,7 +90,7 @@ program gridchg
         open(mfile, file='moldens', form='unformatted', action='write')
         open(pfile, file='dens.mol', action='write')
         norm = 0_rk
-        !nullify(xyzw)
+        nullify(xyzw)
         mol_grid_batches: do ib = 1,nbatch
             !
             !  Get grid points
@@ -170,11 +170,11 @@ program gridchg
         iat = den_grid%next_part
         normatm = 0_rk
         dcharge = 0_rk
+        !nullify(xyzw)
         grid_batches: do ib = 1,nbatch
             !
             !  Get grid points
             !
-            nullify(xyzw)
             call GridPointsBatch(den_grid, 'Next batch', xyzw=xyzw)
             !
             !  If the batch size changed, reallocate density and weight arrays

--- a/import_gamess.f90
+++ b/import_gamess.f90
@@ -1,7 +1,7 @@
 !
 !  Import simple GAMESS checkpoint files.
 !
-!  Restrictions: 
+!  Restrictions:
 !    Only C1 symmetry (no symmetry) is allowed.
 !    Basis sets must be in-line.
 !    Only simple, single-SCF files are supported.
@@ -14,7 +14,7 @@
 !
 !  Added Feb 2010 (Michael Spanner): Support for loading natural orbital occupation numbers
 !                                    and rdm_sv values from the GAMESS checkpoint files.
-!  Added March 2010 (Michael Spanner): Support for rotating the gamess data relative to multigrid 
+!  Added March 2010 (Michael Spanner): Support for rotating the gamess data relative to multigrid
 !
 !  Added Aug 2011 (SP): Support for 3-centre 1e integral evaluation. The 3-centre integrals
 !                       implementation is essentiall Obara-Saika, with the extensions to
@@ -44,8 +44,8 @@
 !
 !  Apr 23, 2014 (SP): Added support for (most) integrals in quadruple precision.
 !
-!  In order to remain compatible with historical usage in multigrid, we 
-!  maintain a default structure context; all calls which do not specify 
+!  In order to remain compatible with historical usage in multigrid, we
+!  maintain a default structure context; all calls which do not specify
 !  (one of the) context(s) default to that one.
 !
   module import_gamess
@@ -75,7 +75,7 @@
     !
     !  Conditional compilation is needed for the interfaces:
     !  the _quad versions differ only in their argument kinds; if we
-    !  compile with real and quad kinds being the same, the interface 
+    !  compile with real and quad kinds being the same, the interface
     !  part will fail!
     !
     interface gamess_print_1e_integrals
@@ -193,7 +193,7 @@
                      target, optional :: structure   ! Context to use
       logical, intent(in), optional   :: true_charge ! Report true nuclear charge, including the ECP charge
       !
-      type(gam_structure), pointer :: gam          
+      type(gam_structure), pointer :: gam
       integer(ik)                  :: na
       logical                      :: add_ecp
       !
@@ -274,7 +274,7 @@
       gam%nbatches = 0
     end subroutine gamess_destroy
     !
-    !  Load structure file and evaluate the MOs. This subroutine is a little 
+    !  Load structure file and evaluate the MOs. This subroutine is a little
     !  complicated, since it can perform three separate functions:
     !
     !  1. Parse GAMESS checkpoint file, and remember the result. In this case,
@@ -305,7 +305,7 @@
                                              :: structure      ! Context to use
       real(rk), intent(in), optional        :: rot(:,:)       ! Rotation matrix to apply to the structure. It is
                                                                ! perfectly OK to use different rotation matrix
-                                                               ! in different calls using the same context. 
+                                                               ! in different calls using the same context.
                                                                ! If the rotation matrix is not given for a call where
                                                                ! file= is specified, it will be reset to unit matrix.
                                                                ! If the rotation matrix is not given for a pure-evaluation
@@ -391,7 +391,7 @@
       !
       if (evaluate_mos .and. .not.load_mos) then
         if (.not.allocated(gam%atoms) .or. .not.allocated(gam%vectors)) then
-          write (out,"('import_gamess%gamess_load_orbitals: basis set and/or orbitals are not present')") 
+          write (out,"('import_gamess%gamess_load_orbitals: basis set and/or orbitals are not present')")
           stop 'import_gamess%gamess_load_orbitals: basis set and/or orbitals are not present'
         end if
       end if
@@ -446,7 +446,7 @@
         call TimerStop('GAMESS import - orbitals')
       end if ! evaluate_mos
       !
-      !  Special logic for the legacy semantics - MO matrix may be quite large, 
+      !  Special logic for the legacy semantics - MO matrix may be quite large,
       !  and it won't be needed after this point.
       !
       if (load_mos .and. evaluate_mos) then
@@ -560,8 +560,8 @@
                                           :: structure   ! Context to use
       real(rk), intent(in), optional     :: rot(:,:)    ! Rotation matrix to apply to the structure. It is
                                                          ! perfectly OK to use different rotation matrix
-                                                         ! in different calls using the same context. 
-                                                         ! If the rotation matrix is not given, rotation matrix 
+                                                         ! in different calls using the same context.
+                                                         ! If the rotation matrix is not given, rotation matrix
                                                          ! from the previous call will be used.
       !
       type(gam_structure), pointer :: gam
@@ -592,7 +592,7 @@
       end if
       !
       if (.not.allocated(gam%atoms)) then
-        write (out,"('import_gamess%gamess_evaluate_functions: basis set is not present')") 
+        write (out,"('import_gamess%gamess_evaluate_functions: basis set is not present')")
         stop 'import_gamess%gamess_evaluate_functions: basis set is not present'
       end if
       !
@@ -627,7 +627,7 @@
       end if
       have_natocc = .false.
       scan_lines: do while (.not.have_natocc)
-        call gam_readline 
+        call gam_readline
         if (gam_line_buf==' $OCCNO ') then
           call parse_natocc_data(natural_occ,natural_count)
           have_natocc = .true.
@@ -637,7 +637,7 @@
       call TimerStop('GAMESS import natocc')
     end subroutine gamess_load_natocc
     !
-    !  Load the transition density decomposition singular values 
+    !  Load the transition density decomposition singular values
     !
     subroutine gamess_load_rdmsv(file,rdm_sv,rdm_count)
       character(len=*), intent(in) :: file            ! Name of the GAMESS checkpoint file
@@ -657,7 +657,7 @@
       end if
       have_rdm = .false.
       scan_lines: do while (.not.have_rdm)
-        call gam_readline 
+        call gam_readline
         if (gam_line_buf==' $RDMPCE') then
           call parse_rdmsv_data(rdm_sv,rdm_count)
           have_rdm = .true.
@@ -754,7 +754,9 @@
         !
         !  First the integrals where no additional parmaters are needed:
         !
-        !  'AO PLANEWAVE'  - Complex planewave operator [Exp(I K R)]; needs K vector
+        !  'AO PLANEWAVE'   - Complex planewave operator [Exp(I K R)]; needs K vector
+        !  'AO R PLANEWAVE' - Component of R (X, Y, or Z), times the planewave.
+        !                     Neeeds K vector and the X/Y/Z index.
         !
         case ('AO PLANEWAVE')
           if (.not.present(op_param)) then
@@ -766,6 +768,26 @@
             stop 'import_gamess%gamess_1e_integrals_complex: Wrong parameter count'
           end if
           op_data%kvec = real(op_param(1:3),kind=kind(op_data%kvec))
+          call os_1e_matrix(op_data,l,r,v)
+        case ('AO R PLANEWAVE')
+          if (.not.present(op_param)) then
+            write (out,"('import_gamess%gamess_1e_integrals_complex: exponent missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals_complex: Missing operator parameter'
+          end if
+          if (size(op_param)/=3) then
+            write (out,"('import_gamess%gamess_1e_integrals_complex: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals_complex: Wrong parameter count'
+          end if
+          op_data%kvec = real(op_param(1:3),kind=kind(op_data%kvec))
+          if (.not.present(op_index)) then
+            write (out,"('import_gamess%gamess_1e_integrals_complex: index missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals_complex: Missing operator parameter'
+          end if
+          if (size(op_index)/=1) then
+            write (out,"('import_gamess%gamess_1e_integrals_complex: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals_complex: Wrong parameter count'
+          end if
+          op_data%op_i = op_index(1)
           call os_1e_matrix(op_data,l,r,v)
       end select
       call TimerStop('GAMESS '//trim(what))
@@ -850,15 +872,15 @@
       usegfmt = any(abs(v)>=1e5) .or. all(abs(v)<=1e-3)
       print_pages: do ic_p1=1,r%nbasis,cpp
         ic_pn = min(r%nbasis,ic_p1+cpp-1)
-        write (out,"(t17,5(2x,i12,1x,12x))") (ic,               ic=ic_p1,ic_pn)
-        if (head=='BOTH') write (out,"(t23,5(2x,a12,1x,12x))") (r%bas_labels(ic), ic=ic_p1,ic_pn)
+        write (out,"(t19,5(2x,i12,1x,12x))") (ic,               ic=ic_p1,ic_pn)
+        if (head=='BOTH') write (out,"(t25,5(2x,a13,1x,11x))") (r%bas_labels(ic), ic=ic_p1,ic_pn)
         print_rows: do ir=1,l%nbasis
           lab = ' '
           if (head/='NONE') lab = l%bas_labels(ir)
           if (usegfmt) then
-            write (out,"(1x,i5,1x,a11,1x,5(2x,g12.5,1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+            write (out,"(1x,i5,1x,a13,1x,5(2x,g12.5,1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
           else
-            write (out,"(1x,i5,1x,a11,1x,5(2x,f12.5,1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+            write (out,"(1x,i5,1x,a13,1x,5(2x,f12.5,1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
           endif
         end do print_rows
         write (out,"()")
@@ -930,7 +952,7 @@
                                                                        ! molecule - not that this is hard for an AO integral
       real(rk), intent(in), optional                    :: op_param(:) ! Additional parameters for the operator
       real(rk), intent(in), optional                    :: accuracy    ! Desired accuracy of the integrals; contributions
-                                                                       ! smaller than this can be neglected. 
+                                                                       ! smaller than this can be neglected.
                                                                        ! The default is to be as accurate as possible.
                                                                        ! Negative accuracy will restore the default behaviour
       !
@@ -949,7 +971,7 @@
                                                                        ! molecule - not that this is hard for an AO integral
       real(xrk), intent(in), optional                   :: op_param(:) ! Additional parameters for the operator
       real(xrk), intent(in), optional                   :: accuracy    ! Desired accuracy of the integrals; contributions
-                                                                       ! smaller than this can be neglected. 
+                                                                       ! smaller than this can be neglected.
                                                                        ! The default is to be as accurate as possible.
                                                                        ! Negative accuracy will restore the default behaviour
       !
@@ -963,9 +985,9 @@
       integer(ik)                        :: iat, ish
       !
       allocate (gam%atoms(gam_max_atoms))
-      ! 
+      !
       !  Comment line - ignore
-      !  
+      !
       call gam_readline ; call echo(1_ik)
       !
       !  Symmetry line. We'll only accept C1.
@@ -980,7 +1002,7 @@
       !  Begin loading geometry, COORD=UNIQUE format
       !
       gam%natoms = 0
-      load_atoms: do 
+      load_atoms: do
         call gam_readline ; call echo(1_ik)
         if (gam_line_buf==' $END') exit load_atoms
         gam%natoms = gam%natoms + 1
@@ -996,9 +1018,9 @@
       if (gam%natoms==0) then
         stop 'import_gamess%parse_geometry_data - Found no atoms!'
       end if
-      ! 
+      !
       !  Count basis functions and contractions
-      !  
+      !
       gam%nbasis = 0
       gam%max_contractions = 0
       count_basis: do iat=1,gam%natoms
@@ -1036,14 +1058,14 @@
       integer(ik)  :: shell_size         ! Number of orbitals in the current shell
       integer(ik)  :: sh_l               ! Angular momentum of the current shell
       !
-      !  Count batches 
+      !  Count batches
       !
       gam%nbatches   = 0
       gam%max_shells = 0
       !
       count_2e_batches_atoms: do iat=1,gam%natoms
         if (gam%atoms(iat)%nshell<=0) cycle count_2e_batches_atoms
-        gam%nbatches   = gam%nbatches + 1 
+        gam%nbatches   = gam%nbatches + 1
         batch_shells   = 1
         gam%max_shells = max(gam%max_shells,batch_shells)
         sh_l           = gam%atoms(iat)%sh_l(1)
@@ -1169,7 +1191,7 @@
       !
       atom%nshell  = 0 ;
       atom%sh_p(1) = 1 ;
-      read_shells: do 
+      read_shells: do
         call gam_readline ; call echo(1_ik)
         if (gam_line_buf==' ') exit read_shells ! End of atom data
         read (gam_line_buf,*,iostat=ios) lcode, nprim
@@ -1199,6 +1221,8 @@
           case ('D') ; atom%sh_l(atom%nshell) = 2
           case ('F') ; atom%sh_l(atom%nshell) = 3
           case ('G') ; atom%sh_l(atom%nshell) = 4
+          case ('H') ; atom%sh_l(atom%nshell) = 5
+          case ('I') ; atom%sh_l(atom%nshell) = 6
         end select
         !
         pprim = atom%sh_p(atom%nshell)
@@ -1271,13 +1295,13 @@
       !  for the detailed description of what we are missing here
       !
       iat = 0
-      load_atoms: do 
+      load_atoms: do
         call gam_readline ; call echo(1_ik)
         if (gam_line_buf==' $END') exit load_atoms
         !
         iat = iat + 1
         if (iat>gam%natoms) then
-          write (out,"('import_gamess%parse_ecp_data: More ECPs than there are atoms.')") 
+          write (out,"('import_gamess%parse_ecp_data: More ECPs than there are atoms.')")
           write (out,"('Last processed line: ',a)") trim(gam_line_buf)
           stop 'import_gamess%parse_ecp_data - too many ECPs'
         end if
@@ -1443,6 +1467,8 @@
           case ('D') ; atom%sh_l(atom%nshell) = 2
           case ('F') ; atom%sh_l(atom%nshell) = 3
           case ('G') ; atom%sh_l(atom%nshell) = 4
+          case ('H') ; atom%sh_l(atom%nshell) = 5
+          case ('I') ; atom%sh_l(atom%nshell) = 6
         end select
         !
         pprim = atom%sh_p(atom%nshell)
@@ -1531,7 +1557,7 @@
                  ios, trim(gam_line_buf)
           stop 'import_gamess%parse_orbital_data - format error'
         end if
-        ! 
+        !
         !  Line parsed, check it for validity
         !
         wrap_mo = gam%nvectors+1
@@ -1589,7 +1615,7 @@
                  ios, trim(gam_line_buf)
           stop 'import_gamess%parse_natocc_data - format error (1)'
         end if
-        ! 
+        !
         line_numocc = len_trim(gam_line_buf)/16
         !
         if (line_numocc>5) then
@@ -1599,13 +1625,13 @@
         end if
         !
         if ( (natural_count+line_numocc)>max_numocc) then
-          write (out,"('import_gamess%parse_natocc_data: too many natural orbitals in file. Increase max_naturals and recompile.')") 
+          write (out,"('import_gamess%parse_natocc_data: too many natural orbitals in file. Increase max_naturals and recompile.')")
           stop 'import_gamess%parse_natocc_data - too many natural orbitals - increase max_naturals and recompile.'
         end if
         !
         natural_occ(natural_count+1:natural_count+line_numocc) = loc_val(1:line_numocc)
         natural_count = natural_count + line_numocc
-        ! 
+        !
       end do read_natocc
       !
       if (verbose>=0) then
@@ -1636,7 +1662,7 @@
                  ios, trim(gam_line_buf)
           stop 'import_gamess%parse_rdmsv_data - format error (1)'
         end if
-        ! 
+        !
         line_numsv = len_trim(gam_line_buf)/15
         !
         if (line_numsv>5) then
@@ -1646,13 +1672,13 @@
         end if
         !
         if ( (rdm_count+line_numsv)>max_numsv) then
-          write (out,"('import_gamess%parse_rdmsv_data: too many rdm orbitals in file. Increase max_rdm and recompile.')") 
+          write (out,"('import_gamess%parse_rdmsv_data: too many rdm orbitals in file. Increase max_rdm and recompile.')")
           stop 'import_gamess%parse_rdmsv_data - too many rdm orbitals - increase max_rdm and recompile.'
         end if
         !
         rdm_sv(rdm_count+1:rdm_count+line_numsv) = loc_val(1:line_numsv)
         rdm_count = rdm_count + line_numsv
-        ! 
+        !
       end do read_rdmsv
       !
       if (verbose>=0) then
@@ -1686,9 +1712,9 @@
                                                          ! The last index is for the MOs.
       !
       integer(ik), allocatable  :: special_pt(:,:)    ! Grid points, where oversampling is deemed
-                                                      ! necessary. The final 3 entries are the expected 
+                                                      ! necessary. The final 3 entries are the expected
                                                       ! number or samples per point.
-      real(rk)                  :: r_cut              ! Max distance from the nearest nucleus to 
+      real(rk)                  :: r_cut              ! Max distance from the nearest nucleus to
                                                       ! trigger oversampling
       integer(ik)               :: num_special        ! Number of grid points requiring special treatment
       integer(ik)               :: num_special_max    ! (Estimate of the maximum possible # of the special points
@@ -1696,7 +1722,7 @@
       integer(ik)               :: isp                ! Special-point index
 !
 !    For some reason, GNU Fortran has trouble with private automatic arrays - they seem to
-!    cause segmentation faults in parallel runs. We'll simply have to allicate basval 
+!    cause segmentation faults in parallel runs. We'll simply have to allicate basval
 !    inside the parallel section ....
 !
 !     real(rk)                 :: basval(gam%nbasis) ! local buffer for basis function values
@@ -1730,7 +1756,7 @@
               call evaluate_basis_functions(gam,coord(1:3,ipx,ipy,ipz),basval)
               !
               !  Loop over MOs
-              ! 
+              !
               grid(ipx,ipy,ipz,dst) = matmul(basval,gam%vectors(:,mos))
             end do grid_x1
           end do grid_y1
@@ -1744,7 +1770,7 @@
             call evaluate_basis_functions(gam,coord(1:3,ipx,ipy,1),basval)
             !
             !  Loop over MOs
-            ! 
+            !
             grid(ipx,ipy,1,dst) = matmul(basval,gam%vectors(:,mos))
           end do grid_x2
         end do grid_y2
@@ -1756,7 +1782,7 @@
           call evaluate_basis_functions(gam,coord(1:3,ipx,1,1),basval)
           !
           !  Loop over MOs
-          ! 
+          !
           grid(ipx,1,1,dst) = matmul(basval,gam%vectors(:,mos))
         end do grid_x3
         !$omp end do
@@ -1764,7 +1790,7 @@
       if (verbose>=0 .and. num_special>0) then
         !$omp single
         write (out,"(/'Number of grid points requiring oversampling: ',i8/)") num_special
-        if (num_special>0 .and. verbose>3) then 
+        if (num_special>0 .and. verbose>3) then
           report_special: do isp=1,num_special
             ipx = special_pt(1,isp)
             ipy = special_pt(2,isp)
@@ -1777,7 +1803,7 @@
       end if
       !
       !  The required degree of oversampling is likely to be (very) different for each volume
-      !  element. In this situation, the only reasonable schedule is "dynamic". An alternative 
+      !  element. In this situation, the only reasonable schedule is "dynamic". An alternative
       !  would be to parallelize individual volume elements; if load balancing becomes an issue,
       !  that's the natural thing to try.
       !
@@ -1840,9 +1866,9 @@
         !
         call get_oversampling_order(ord,gam,abs_xyz)
         !
-        !  This volume element needs to be sub-sampled - Update the hit list. 
-        !  Since this routine is executing concurrently, we have to excercise 
-        !  a bit of care! 
+        !  This volume element needs to be sub-sampled - Update the hit list.
+        !  Since this routine is executing concurrently, we have to excercise
+        !  a bit of care!
         !
         if (product(ord)>1) then
         !$omp critical
@@ -1952,7 +1978,7 @@
           !
           if (verbose>=2 .or. warn_symmetry) then
             !$omp critical
-          
+
             if (verbose>=2 .or. warn_symmetry) then
               write (out,"(/'Unable to consistently oversample orbital at grid point ',3(1x,f14.7))") coord
               write (out,"('Central value: ',g14.7,' average: ',g14.7,' root of average square: ',g14.7/)") &
@@ -2041,7 +2067,7 @@
         end do scan_shells
       end do scan_atoms
       !
-      !  Now scale the number of primitives across the diagonal according to the 
+      !  Now scale the number of primitives across the diagonal according to the
       !  linear extent of each dimension
       !
       ord = ceiling( (gam%dx * npts) / diag)
@@ -2062,8 +2088,8 @@
       integer(ik)             :: p_bas
       type(gam_atom), pointer :: at
       real(rk)                :: rot_xyz(3)
-      real(rk)                :: xyz(3,0:5), r2
-      real(rk)                :: ang(0:34)
+      real(rk)                :: xyz(3,0:7), r2
+      real(rk)                :: ang(0:gam_nxyz-1)
       real(rk)                :: radial, exparg
 !     real(rk)                :: ang_c_kind(lbound(ang_c,dim=1):ubound(ang_c,dim=1))
 !     !
@@ -2076,7 +2102,7 @@
       rot_xyz = matmul(transpose(gam%rotmat_rk),abs_xyz)
       !
       !  Process all centres containing basis functions
-      ! 
+      !
       p_bas = 1
       atom_loop: do iat=1,gam%natoms
         at => gam%atoms(iat)
@@ -2094,6 +2120,8 @@
         xyz(:,3) = xyz(:,1)*xyz(:,2)
         xyz(:,4) = xyz(:,2)**2
         xyz(:,5) = xyz(:,2)*xyz(:,3)
+        xyz(:,6) = xyz(:,3)**2
+        xyz(:,7) = xyz(:,4)*xyz(:,3)
         !
         !  Calculate square distance
         !
@@ -2141,10 +2169,10 @@
     subroutine evaluate_basis_functions_and_gradients(gam,abs_xyz,basval)
       type(gam_structure), target, intent(in) :: gam          ! Context to use
       real(rk), intent(in)                    :: abs_xyz(:)   ! Coordinates of the point
-      real(rk), intent(out)                  :: basval(:,:)  ! First index:
+      real(rk), intent(out)                   :: basval(:,:)  ! First index:
                                                               ! 1 = Values of the basis functions
                                                               ! 2 = X gradient of the basis function, etc
-                                                               
+
       !
       integer(ik)             :: iat, ish
       integer(ik)             :: ip1, ip2, ip
@@ -2152,8 +2180,8 @@
       integer(ik)             :: p_bas
       type(gam_atom), pointer :: at
       real(rk)                :: rot_xyz(3)
-      real(rk)                :: xyz(3,-1:6), r2
-      real(rk)                :: ang(0:34), angd(3,0:34), angu(3,0:34)
+      real(rk)                :: xyz(3,-1:8), r2
+      real(rk)                :: ang(0:gam_nxyz-1), angd(3,0:gam_nxyz-1), angu(3,0:gam_nxyz-1)
       real(rk)                :: radial, radial2, exparg
 !     real(rk)                :: ang_c_kind(lbound(ang_c,dim=1):ubound(ang_c,dim=1))
 !     !
@@ -2166,7 +2194,7 @@
       rot_xyz = matmul(transpose(gam%rotmat_rk),abs_xyz)
       !
       !  Process all centres containing basis functions
-      ! 
+      !
       p_bas = 1
       atom_loop: do iat=1,gam%natoms
         at => gam%atoms(iat)
@@ -2185,7 +2213,9 @@
         xyz(:, 3) = xyz(:,1)*xyz(:,2)
         xyz(:, 4) = xyz(:,2)**2
         xyz(:, 5) = xyz(:,2)*xyz(:,3)
-        xyz(:, 6) = xyz(:,3)*xyz(:,3)
+        xyz(:, 6) = xyz(:,3)**2
+        xyz(:, 7) = xyz(:,4)*xyz(:,3)
+        xyz(:, 8) = xyz(:,4)**2
         !
         !  Calculate square distance
         !
@@ -2251,7 +2281,7 @@
       include 'import_gamess_os_1e_matrix_common.f90'
     end subroutine os_1e_matrix_real
     !
-    !  Real operators, quad accuracy. 
+    !  Real operators, quad accuracy.
     !
     subroutine os_1e_matrix_quad(what,l,r,v)
       type (gam_operator_data), intent(in) :: what   ! Operator to evaluate
@@ -2283,9 +2313,9 @@
       real(rk), intent(in)                :: z_l(:)  ! Primitive exponents on the left
       real(rk), intent(in)                :: c_l(:)  ! Contractions on the left
       real(rk), intent(in)                :: r_r(:)  ! Ditto on the right
-      integer(ik), intent(in)              :: l_r     ! 
-      real(rk), intent(in)                :: z_r(:)  ! 
-      real(rk), intent(in)                :: c_r(:)  ! 
+      integer(ik), intent(in)              :: l_r     !
+      real(rk), intent(in)                :: z_r(:)  !
+      real(rk), intent(in)                :: c_r(:)  !
       !
       include 'import_gamess_os_1e_contraction_common.f90'
     end subroutine os_1e_contraction_real
@@ -2300,9 +2330,9 @@
       real(xrk), intent(in)                :: z_l(:)  ! Primitive exponents on the left
       real(xrk), intent(in)                :: c_l(:)  ! Contractions on the left
       real(xrk), intent(in)                :: r_r(:)  ! Ditto on the right
-      integer(ik), intent(in)              :: l_r     ! 
-      real(xrk), intent(in)                :: z_r(:)  ! 
-      real(xrk), intent(in)                :: c_r(:)  ! 
+      integer(ik), intent(in)              :: l_r     !
+      real(xrk), intent(in)                :: z_r(:)  !
+      real(xrk), intent(in)                :: c_r(:)  !
       !
       include 'import_gamess_os_1e_contraction_common.f90'
     end subroutine os_1e_contraction_quad
@@ -2317,9 +2347,9 @@
       real(rk), intent(in)                :: z_l(:)  ! Primitive exponents on the left
       real(rk), intent(in)                :: c_l(:)  ! Contractions on the left
       real(rk), intent(in)                :: r_r(:)  ! Ditto on the right
-      integer(ik), intent(in)              :: l_r     ! 
-      real(rk), intent(in)                :: z_r(:)  ! 
-      real(rk), intent(in)                :: c_r(:)  ! 
+      integer(ik), intent(in)              :: l_r     !
+      real(rk), intent(in)                :: z_r(:)  !
+      real(rk), intent(in)                :: c_r(:)  !
       !
       integer(ik)              :: ic_l, p1_l, p2_l, p_l, int_l
       integer(ik)              :: ic_r, p1_r, p2_r, p_r, int_r
@@ -2347,6 +2377,8 @@
           n_rec = l_l + l_r
         case ('PLANEWAVE')
           n_rec = 0
+        case ('R PLANEWAVE')
+          n_rec = 1
       end select
       allocate (vb_r(0:p2_l,0:p2_r,0:n_rec),stat=alloc)
       if (alloc/=0) then
@@ -2368,6 +2400,15 @@
               stop 'import_gamess%os_1e_contraction_complex: Unimplemented property'
             case ('PLANEWAVE')
               call os_1e_planewave(p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r),real(what%kvec,kind=kind(vb_r)))
+            case ('R PLANEWAVE')
+              if (what%op_i<1 .or. what%op_i>3) then
+                write (out,"('import_gamess%os_1e_contraction_complex: Dipole component ',i0,' is not between 1 and 3 in ',a)") &
+                       what%op_i, trim(what%op_name)
+                stop 'import_gamess%os_1e_contraction_complex: Bad dipole'
+              end if
+              call os_1e_planewave(p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r),real(what%kvec,kind=kind(vb_r)))
+              call os_1e_pwdipole (what%op_i,vb_r(:,:,1), &
+                                   p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r),real(what%kvec,kind=kind(vb_r)))
           end select
           !
           wgt = c_l(ic_l) * c_r(ic_r)
@@ -2396,7 +2437,7 @@
       real(rk), intent(in)    :: r_l(:)             ! Centre of the left b.f.
       real(rk), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
       real(rk), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
-      real(rk), intent(in)    :: z_r                ! 
+      real(rk), intent(in)    :: z_r                !
       !
       include 'import_gamess_os_1e_overlap_common.f90'
     end subroutine os_1e_overlap_real
@@ -2409,7 +2450,7 @@
       real(xrk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(xrk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(xrk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(xrk), intent(in)   :: z_r                 ! 
+      real(xrk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_overlap_common.f90'
     end subroutine os_1e_overlap_quad
@@ -2423,7 +2464,7 @@
       real(rk), intent(in)    :: r_l(:)              ! Centre of the left b.f.
       real(rk), intent(in)    :: z_l                 ! Orbital exponent of the left b.f.
       real(rk), intent(in)    :: r_r(:)              ! ditto, for the right b.f.
-      real(rk), intent(in)    :: z_r                 ! 
+      real(rk), intent(in)    :: z_r                 !
       real(rk), intent(in)    :: kvec(3)             ! Planewave momentum
       !
       real(rk)    :: zeta, xi, p(3), s00
@@ -2436,7 +2477,7 @@
       !
       vb_p(0,0) = s00 * exp(-sum(kvec**2)/(4*zeta)) * exp((0,1)*sum(kvec*p))
       !
-      !  Bootstrap: calculate all overlaps on the right, keeping left at zero. 
+      !  Bootstrap: calculate all overlaps on the right, keeping left at zero.
       !
       right_bootstrap: do m_r=1,p2_r
         find_right: do ic=1,3
@@ -2450,7 +2491,7 @@
         end do find_right
       end do right_bootstrap
       !
-      !  Now the general case: always recurse on the left. 
+      !  Now the general case: always recurse on the left.
       !
       right_loop: do m_r=0,p2_r
         left_recurrence: do m_l=1,p2_l
@@ -2479,7 +2520,7 @@
       real(rk), intent(in)    :: r_l(:)             ! Centre of the left b.f.
       real(rk), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
       real(rk), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
-      real(rk), intent(in)    :: z_r                ! 
+      real(rk), intent(in)    :: z_r                !
       !
       include 'import_gamess_os_1e_dipole_common.f90'
     end subroutine os_1e_dipole_real
@@ -2494,10 +2535,45 @@
       real(xrk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(xrk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(xrk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(xrk), intent(in)   :: z_r                 ! 
+      real(xrk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_dipole_common.f90'
     end subroutine os_1e_dipole_quad
+    !
+    !  Note that we are using a simpler, direct expression in terms of overlap integrals.
+    !  Effectively, we first recurse over the components of the moment operator, then
+    !  over the function. Our real dipole expressions are instead in terms of the much
+    !  more complex O&S recursion, which recurses over the function first.
+    !
+    subroutine os_1e_pwdipole(id,vb_s,p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r,kvec)
+      integer(ik), intent(in)  :: id                  ! Dipole component to evaluate
+      integer(ik), intent(in)  :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+      complex(rk), intent(in)  :: vb_s(0:p2_l,0:p2_r) ! Buffer containing primitive overlaps
+      complex(rk), intent(out) :: vb_p(0:p2_l,0:p2_r) ! Final result.
+      real(rk), intent(in)     :: r_l(:)              ! Centre of the left b.f.
+      real(rk), intent(in)     :: z_l                 ! Orbital exponent of the left b.f.
+      real(rk), intent(in)     :: r_r(:)              ! ditto, for the right b.f.
+      real(rk), intent(in)     :: z_r                 !
+      real(rk), intent(in)     :: kvec(3)             ! Planewave momentum
+      !
+      real(kind(z_l))    :: zeta, p(3)
+      complex(kind(z_l)) :: s, scl00
+      integer(ik)        :: m_l, m_r, id1, id2
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,zeta=zeta,p=p)
+      scl00 = p(id) + (0,1)*kvec(id)/(2*zeta)
+      !
+      right_loop: do m_r=0,p2_r
+        left_loop: do m_l=0,p2_l
+          s   = scl00 * vb_s(m_l,m_r)
+          id1 = drop_xyz(m_l,id)
+          id2 = drop_xyz(m_r,id)
+          if (id1>=0) s = s + vb_s(id1,m_r) * ang_nxyz(m_l,id)/(2*zeta)
+          if (id2>=0) s = s + vb_s(m_l,id2) * ang_nxyz(m_r,id)/(2*zeta)
+          vb_p(m_l,m_r) = s
+        end do left_loop
+      end do right_loop
+    end subroutine os_1e_pwdipole
     !
     !  Calculate primitive matrix elements of (d/dx) operator.
     !  These reduce to linear combinations of overlap integrals, so it's extra easy.
@@ -2511,7 +2587,7 @@
       real(rk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(rk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(rk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(rk), intent(in)   :: z_r                 ! 
+      real(rk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_grad_common.f90'
     end subroutine os_1e_grad_real
@@ -2524,7 +2600,7 @@
       real(xrk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(xrk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(xrk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(xrk), intent(in)   :: z_r                 ! 
+      real(xrk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_grad_common.f90'
     end subroutine os_1e_grad_quad
@@ -2542,7 +2618,7 @@
       real(rk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(rk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(rk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(rk), intent(in)   :: z_r                 ! 
+      real(rk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_rddr_common.f90'
     end subroutine os_1e_rddr_real
@@ -2557,7 +2633,7 @@
       real(xrk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(xrk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(xrk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(xrk), intent(in)   :: z_r                 ! 
+      real(xrk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_rddr_common.f90'
     end subroutine os_1e_rddr_quad
@@ -2573,7 +2649,7 @@
       real(rk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(rk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(rk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(rk), intent(in)   :: z_r                 ! 
+      real(rk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_kinetic_common.f90'
     end subroutine os_1e_kinetic_real
@@ -2587,7 +2663,7 @@
       real(xrk), intent(in)   :: r_l(:)              ! Centre of the left b.f.
       real(xrk), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
       real(xrk), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-      real(xrk), intent(in)   :: z_r                 ! 
+      real(xrk), intent(in)   :: z_r                 !
       !
       include 'import_gamess_os_1e_kinetic_common.f90'
     end subroutine os_1e_kinetic_quad
@@ -2606,7 +2682,7 @@
       real(rk), intent(in)    :: r_l(:)                      ! Centre of the left b.f.
       real(rk), intent(in)    :: z_l                         ! Orbital exponent of the left b.f.
       real(rk), intent(in)    :: r_r(:)                      ! ditto, for the right b.f.
-      real(rk), intent(in)    :: z_r                         ! 
+      real(rk), intent(in)    :: z_r                         !
       !
       include 'import_gamess_os_1e_3c_common.f90'
     end subroutine os_1e_3c_real
@@ -2620,13 +2696,13 @@
       real(xrk), intent(in)    :: r_l(:)                      ! Centre of the left b.f.
       real(xrk), intent(in)    :: z_l                         ! Orbital exponent of the left b.f.
       real(xrk), intent(in)    :: r_r(:)                      ! ditto, for the right b.f.
-      real(xrk), intent(in)    :: z_r                         ! 
+      real(xrk), intent(in)    :: z_r                         !
       !
       include 'import_gamess_os_1e_3c_common.f90'
     end subroutine os_1e_3c_quad
     !
     !  4-centre 2-electron integrals
-    !  We follow the Ahlrichs' PCCP paper. However, instead of using the transfer relations, 
+    !  We follow the Ahlrichs' PCCP paper. However, instead of using the transfer relations,
     !  advocated by that paper, we directly use the general recursion formula (31).
     !  This is less computationally efficient than the Ahlrichs' preferred route, but
     !  avoids the need for extending our data tables in gamess_internal.f90.
@@ -2749,7 +2825,7 @@
       real(rk), intent(in)            :: r_l(:)  ! Centre of the left b.f.
       real(rk), intent(in)            :: z_l     ! Orbital exponent of the left b.f.
       real(rk), intent(in)            :: r_r(:)  ! ditto, for the right b.f.
-      real(rk), intent(in)            :: z_r     ! 
+      real(rk), intent(in)            :: z_r     !
       real(rk), intent(out), optional :: xi      ! Eq. 13 of Obara-Saika
       real(rk), intent(out), optional :: zeta    ! Eq. 14
       real(rk), intent(out), optional :: p(:)    ! Eq. 15
@@ -2765,7 +2841,7 @@
       real(xrk), intent(in)            :: r_l(:)  ! Centre of the left b.f.
       real(xrk), intent(in)            :: z_l     ! Orbital exponent of the left b.f.
       real(xrk), intent(in)            :: r_r(:)  ! ditto, for the right b.f.
-      real(xrk), intent(in)            :: z_r     ! 
+      real(xrk), intent(in)            :: z_r     !
       real(xrk), intent(out), optional :: xi      ! Eq. 13 of Obara-Saika
       real(xrk), intent(out), optional :: zeta    ! Eq. 14
       real(xrk), intent(out), optional :: p(:)    ! Eq. 15

--- a/import_gamess_1e_integrals_common.f90
+++ b/import_gamess_1e_integrals_common.f90
@@ -1,0 +1,131 @@
+!   subroutine gamess_1e_integrals_real(what,v,bra,ket,op_xyz,op_param,op_index)
+!     character(len=*), intent(in)      :: what        ! What to evaluate
+!     real(rk), intent(out)             :: v(:,:)      ! Buffer for the results
+!     type(gam_structure), intent(in), target, optional :: bra
+!     type(gam_structure), intent(in), target, optional :: ket
+!     real(rk), intent(in), optional    :: op_xyz(:)   ! Position of the operator (3c integrals)
+!     real(rk), intent(in), optional    :: op_param(:) ! Additional parameters for the operator
+!                                                      ! Required size and allowed values depend on
+!                                                      ! the operator; see below.
+!     integer(ik), intent(in), optional :: op_index(:) ! Additional (integer) parameters for the operator.
+      !
+      character(len=40)            :: lwhat          ! Local copy of "what"
+      type(gam_structure), pointer :: l, r
+      type(gam_operator_data)      :: op_data        ! Operator data
+      !
+      call TimerStart('GAMESS '//trim(what))
+      l => gam_def ; r => gam_def
+      if (present(bra)) l => bra
+      if (present(ket)) r => ket
+      !
+      !  What is it we want to evaluate?
+      !
+      lwhat = what
+      select case (lwhat(1:3))
+        case ('AO ')
+          if ( (size(v,dim=1)<l%nbasis) .or. (size(v,dim=2)<r%nbasis) ) then
+            write (out,"('import_gamess%gamess_1e_integrals: Output buffer is not large enough')")
+            stop 'import_gamess%gamess_1e_integrals: Output buffer is not large enough'
+          end if
+      end select
+      !
+      !  3-centre integrals need position of the operator; make sure it was supplied
+      !  Operator-specific parameters will be handled later.
+      !
+      if (lwhat(4:5)=='3C') then
+        if (.not.present(op_xyz)) then
+          write (out,"('import_gamess%gamess_1e_integrals: operator location missing for ',a)") trim(lwhat)
+          stop 'import_gamess%gamess_1e_integrals: Missing operator position'
+        end if
+        op_data%op_xyz = real(op_xyz,kind=kind(op_data%op_xyz))
+        ! write (out,"('Operator at ',3f20.12)") op_data%op_xyz
+      end if
+      !
+      op_data%op_name = lwhat(4:)
+      !
+      select case (lwhat)
+        case default
+          write (out,"('import_gamess%gamess_1e_integrals_real: ',a,' are not implemented')") trim(lwhat)
+          stop 'import_gamess%gamess_1e_integrals - integral not implemented'
+        !
+        !  2-centre integrals. There is no extra checking and no parameters
+        !
+        case ('AO OVERLAP','AO DIPOLE X','AO DIPOLE Y','AO DIPOLE Z','AO KINETIC','AO D/DX','AO D/DY','AO D/DZ')
+          !
+          !  Each evaluation of the dipole integrals will also evaluate (and discard)
+          !  the overlap integrals. This is not the most efficient way of doing things,
+          !  but do we really care?
+          !
+          call os_1e_matrix(op_data,l,r,v)
+        case ('AO R-D/DR')
+          !
+          !  Two-centre integarls of operator r_i (d/d r_j).
+          !  These integrals are reduced to linear combinations of overlap and dipole integrals
+          !  We need two integer indices, both in the range 1-3
+          !
+          if (.not.present(op_index)) then
+            write (out,"('import_gamess%gamess_1e_integrals: indices missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Missing operator parameter'
+          end if
+          if (size(op_index)/=2) then
+            write (out,"('import_gamess%gamess_1e_integrals: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Wrong parameter count'
+          end if
+          op_data%op_i = op_index(1)
+          op_data%op_j = op_index(2)
+          if (op_data%op_i<1 .or. op_data%op_i>3 .or. op_data%op_j<1 .or. op_data%op_j>3) then
+            write (out,"('import_gamess%gamess_1e_integrals: index parameters out of range for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Parameters out of range'
+          end if
+          call os_1e_matrix(op_data,l,r,v)
+        !
+        !  3-centre integrals. We may need to do extra work here.
+        !
+        !  First the integrals where no additional parmaters are needed:
+        !
+        !  'AO 3C DELTA'     - Delta-function at C (I know it's silly)
+        !  'AO 3C ONE'       - Very complicated 2-centre overlap implementation
+        !  'AO 3C 1/R'       - Nuclear attraction
+        !  'AO 3C R'         - Linear attraction
+        !  'AO 3C R**2'      - Harmonic attraction
+        !
+        case ('AO 3C DELTA', 'AO 3C ONE', 'AO 3C 1/R', 'AO 3C R', 'AO 3C R**2')
+          call os_1e_matrix(op_data,l,r,v)
+        !
+        !  Operators containing a Gaussian at C; need the exponent.
+        !
+        !  'AO 3C GAUSS'     - Three-centre overlap
+        !  'AO 3C GAUSS ONE' - Ditto, but a more complicated implementation
+        !  'AO 3C GAUSS R'   - Gaussian-damped linear attraction
+        !
+        case ('AO 3C GAUSS', 'AO 3C GAUSS ONE', 'AO 3C GAUSS R')
+          if (.not.present(op_param)) then
+            write (out,"('import_gamess%gamess_1e_integrals: exponent missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Missing operator parameter'
+          end if
+          if (size(op_param)/=1) then
+            write (out,"('import_gamess%gamess_1e_integrals: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Wrong parameter count'
+          end if
+          op_data%omega = real(op_param(1),kind=kind(op_data%omega))
+          call os_1e_matrix(op_data,l,r,v)
+        !
+        !  Operators with C at a complex point; need the imaginary component
+        !
+        !  'AO 3C R/(R**2+A**2)' - Real part of the nuclear attraction
+        !  'AO 3C A/(R**2+A**2)' - Imaginary part of the nuclear attraction (with negative sign)
+        !
+        case ('AO 3C R/(R**2+A**2)','AO 3C A/(R**2+A**2)')
+          if (.not.present(op_param)) then
+            write (out,"('import_gamess%gamess_1e_integrals: exponent missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Missing operator parameter'
+          end if
+          if (size(op_param)/=1) then
+            write (out,"('import_gamess%gamess_1e_integrals: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_1e_integrals: Wrong parameter count'
+          end if
+          op_data%imag_rc = real(op_param(1),kind=kind(op_data%imag_rc))
+          call os_1e_matrix(op_data,l,r,v)
+      end select
+      call TimerStop('GAMESS '//trim(what))
+!   end subroutine gamess_1e_integrals_real

--- a/import_gamess_gamess_2e_integrals_common.f90
+++ b/import_gamess_gamess_2e_integrals_common.f90
@@ -10,7 +10,7 @@
 !                                                                      ! molecule - not that this is hard for an AO integral
 !     real(rk), intent(in), optional                    :: op_param(:) ! Additional parameters for the operator
 !     real(rk), intent(in), optional                    :: accuracy    ! Desired accuracy of the integrals; contributions
-!                                                                      ! smaller than this can be neglected. 
+!                                                                      ! smaller than this can be neglected.
 !                                                                      ! The default is to be as accurate as possible.
 !                                                                      ! Negative accuracy will restore the default behaviour
 !     !
@@ -43,10 +43,10 @@
       !
       !  Fill out structure pointers
       !
-      g_a => gam_def ; if (present(a)) g_a => a 
-      g_b => gam_def ; if (present(b)) g_b => b 
-      g_c => gam_def ; if (present(c)) g_c => c 
-      g_d => gam_def ; if (present(d)) g_d => d 
+      g_a => gam_def ; if (present(a)) g_a => a
+      g_b => gam_def ; if (present(b)) g_b => b
+      g_c => gam_def ; if (present(c)) g_c => c
+      g_d => gam_def ; if (present(d)) g_d => d
       !
       !  Allocate local buffers for the exponents and contraction coefficients within the batch
       !
@@ -84,7 +84,7 @@
           !  All parameter-free integrals in os_basic_integral, including:
           !
           !  'AO 4C DELTA'     - Delta-function of r12 (I know it's silly)
-          !                    - It actually isn't - we can use this primitive to compute 
+          !                    - It actually isn't - we can use this primitive to compute
           !                      4-centre 1-electron overlap.
           !  'AO 4C ONE'       - Very complicated implementation of the product of two
           !                      overlap integrals

--- a/import_gamess_gamess_2e_integrals_common.f90
+++ b/import_gamess_gamess_2e_integrals_common.f90
@@ -1,0 +1,216 @@
+!   subroutine gamess_2e_integrals_real(what,v,batch,a,b,c,d,op_param,accuracy)
+!     character(len=*), intent(in)                      :: what        ! What to evaluate
+!     real(rk), intent(out)                             :: v(:,:,:,:)  ! Buffer for the results
+!                                                                      ! Integrals are in the charge-cloud order: that is,
+!                                                                      ! first two indices correspond to the first variable;
+!                                                                      ! the last two indices correspond to the second variable
+!     integer(ik), intent(in)                           :: batch(:)    ! Batch indices
+!     type(gam_structure), intent(in), target, optional :: a, b, c, d  ! Contexts to work on. In principle, we can handle
+!                                                                      ! the situation with every index being on a separate
+!                                                                      ! molecule - not that this is hard for an AO integral
+!     real(rk), intent(in), optional                    :: op_param(:) ! Additional parameters for the operator
+!     real(rk), intent(in), optional                    :: accuracy    ! Desired accuracy of the integrals; contributions
+!                                                                      ! smaller than this can be neglected. 
+!                                                                      ! The default is to be as accurate as possible.
+!                                                                      ! Negative accuracy will restore the default behaviour
+!     !
+      type(gam_structure), pointer :: g_a, g_b, g_c, g_d            ! All missing contexts will be replaced by gam_def
+      type(gam_operator_data)      :: op_data                       ! Operator data
+      real(kind(v))                :: xyz(3,4)                      ! Coordinates of the basis functions within each batch
+      integer(ik)                  :: sh_l (4)                      ! Angular momentum of each batch; all shells within the batch
+                                                                    ! are supposed to have the same angular momentum.
+      integer(ik)                  :: sh_ns(4)                      ! Number of shells in each batch
+      integer(ik), allocatable     :: sh_np(:,:)                    ! Number of primitives in each shell [2nd index]
+      real(kind(v)), allocatable   :: p_zet(:,:,:)                  ! Primitive exponents in each shell [2nd index] and centre [3rd index]
+      real(kind(v)), allocatable   :: p_c  (:,:,:)                  ! Primitive contraction coefficients in each shell
+      real(kind(v)), allocatable   :: p_c_max(:,:,:)                ! Largest absolute contraction coefficient over all instanced of a primitive
+      logical, allocatable         :: p_master(:,:,:)               ! "Master" copy of the exponent; other contractions using the
+                                                                    ! same exponent will be listed in p_z_same
+      integer(ik), allocatable     :: p_z_same(:,:,:,:)             ! Next contraction with an identical exponent
+                                                                    ! First index: 1 = shell index; 2 = contraction within shell
+                                                                    ! 2nd, 3rd, and 4th indices are as the 1st etc in p_zet/p_c/p_master
+      integer(ik)                  :: max_shells                    ! Largest possible batch size across all inputs
+      integer(ik)                  :: max_contractions              ! Longest possible contraction across all inputs
+      integer(ik)                  :: alloc
+      character(len=40)            :: lwhat                         ! Local copy of "what"
+      real(kind(v))                :: cutoff_2e                     ! Cutoff
+      !
+      call TimerStart('GAMESS 2e '//trim(what))
+      !
+      !  Sanity check on the batch() argument
+      !
+      if (size(batch)/=4) stop 'import_gamess%gamess_2e_integrals - bad batch argument'
+      !
+      !  Fill out structure pointers
+      !
+      g_a => gam_def ; if (present(a)) g_a => a 
+      g_b => gam_def ; if (present(b)) g_b => b 
+      g_c => gam_def ; if (present(c)) g_c => c 
+      g_d => gam_def ; if (present(d)) g_d => d 
+      !
+      !  Allocate local buffers for the exponents and contraction coefficients within the batch
+      !
+      max_shells = max(g_a%max_shells,g_b%max_shells,g_c%max_shells,g_d%max_shells)
+      max_contractions = max(g_a%max_contractions,g_b%max_contractions,g_c%max_contractions,g_d%max_contractions)
+      !
+      allocate (sh_np(max_shells,4), &
+                p_zet     (max_contractions,max_shells,4), &
+                p_master  (max_contractions,max_shells,4), &
+                p_c       (max_contractions,max_shells,4), &
+                p_c_max   (max_contractions,max_shells,4), &
+                p_z_same(2,max_contractions,max_shells,4),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('import_gamess%gamess_2e_integrals: Error ',i8,' allocating basis tables')") alloc
+        stop 'import_gamess%gamess_2e_integrals - allocation'
+      end if
+      !
+      !  Check batch indices and corresponding buffer sizes, and fill per-batch data.
+      !
+      call fetch_batch(1_ik,g_a)
+      call fetch_batch(2_ik,g_b)
+      call fetch_batch(3_ik,g_c)
+      call fetch_batch(4_ik,g_d)
+      !
+      lwhat = what
+      op_data%op_name = lwhat(4:)
+      !
+      !
+      select case (what)
+        case default
+          write (out,"('import_gamess%gamess_2e_integrals: ',a,' are not implemented')") trim(what)
+          stop 'import_gamess%gamess_2e_integrals - integral not implemented'
+        case ('AO 4C DELTA','AO 4C ONE','AO 4C 1/R','AO 4C R','AO 4C R**2')
+          !
+          !  All parameter-free integrals in os_basic_integral, including:
+          !
+          !  'AO 4C DELTA'     - Delta-function of r12 (I know it's silly)
+          !                    - It actually isn't - we can use this primitive to compute 
+          !                      4-centre 1-electron overlap.
+          !  'AO 4C ONE'       - Very complicated implementation of the product of two
+          !                      overlap integrals
+          !  'AO 4C 1/R'       - The "usual" 2-electron interaction
+          !  'AO 4C R'         - Linear interaction
+          !  'AO 4C R**2'      - Harmonic interaction
+          !
+        case ('AO 4C GAUSS','AO 4C GAUSS ONE','AO 4C GAUSS R')
+          !
+          !  All integrals taking one parameter in the interaction potential, including:
+          !
+          !  'AO 4C GAUSS'     - Gaussian interaction
+          !  'AO 4C GAUSS ONE' - Ditto, but a more complicated implementation
+          !  'AO 4C GAUSS R'   - Gaussian-damped linear interaction
+          !
+          if (.not.present(op_param)) then
+            write (out,"('import_gamess%gamess_2e_integrals: exponent missing for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_2e_integrals: Missing operator parameter'
+          end if
+          if (size(op_param)/=1) then
+            write (out,"('import_gamess%gamess_2e_integrals: wrong number of parameters for ',a)") trim(lwhat)
+            stop 'import_gamess%gamess_2e_integrals: Wrong parameter count'
+          end if
+          op_data%omega = real(op_param(1),kind=kind(op_data%omega))
+      end select
+      !
+      !  Done with preparations; calculate the integrals!
+      !
+      cutoff_2e = -1
+      if (present(accuracy)) cutoff_2e = accuracy
+      call os_2e_batch(op_data,v,xyz,sh_l,sh_ns,sh_np,p_zet,p_c,p_c_max,p_master,p_z_same,cutoff_2e)
+      deallocate (sh_np,p_zet,p_master,p_c,p_c_max,p_z_same)
+      !
+      call TimerStop('GAMESS 2e '//trim(what))
+      !
+      contains
+      subroutine fetch_batch(ind,gam)
+        integer(ik), intent(in)         :: ind  ! Index in the integral
+        type(gam_structure), intent(in) :: gam  ! Corresponding context
+        !
+        integer(ik)   :: ib           ! Batch number
+        integer(ik)   :: atom         ! Atom index
+        integer(ik)   :: bsize        ! Number of orbitals within this batch
+        integer(ik)   :: shell        ! Shell index within atom's basis
+        integer(ik)   :: is, is2, iso ! Sequential number of a shell within the batch
+        integer(ik)   :: ip, ip2, ipo ! Sequential number of a primitive within a shell
+        integer(ik)   :: sh_p1, sh_pn ! First and last contractions within the shell
+        integer(ik)   :: nc           ! Number of contractions
+        real(kind(v)) :: zref         ! Exponent
+        !
+        ib = batch(ind)
+        if (ib<1 .or. ib>gam%nbatches) then
+          write (out,"('import_gamess%gamess_2e_integrals: ',a,' given bad batch ',i10,' for for index ',i2)") &
+                 trim(what), ib, ind
+          stop 'import_gamess%gamess_2e_integrals: Bad batch index'
+        end if
+        atom  = gam%batches(1,ib)
+        bsize = gam%batches(4,ib)
+        if ( size(v,dim=ind)<bsize ) then
+          write (out,"('import_gamess%gamess_2e_integrals: ',a,' given buffer of size ',i5,' for batch '" &
+                   //",i10,' index ',i2,', but ',i10,' is needed.')") &
+                 trim(what), size(v,dim=ind), ib, ind, bsize
+          stop 'import_gamess%gamess_2e_integrals: Integral buffer too small'
+        end if
+        !
+        !  Remember all the required information about this batch
+        !
+        xyz(:,ind) = real(gam%atoms(atom)%xyz,kind=kind(xyz)) / abohr ! We keep atom coordinates in Angstroms; this keeps biting me..
+        sh_ns(ind) = gam%batches(2,ib)
+        copy_shells: do is=1,sh_ns(ind)
+          shell              = gam%batches(4+is,ib)
+          sh_l (ind)         = gam%atoms(atom)%sh_l(shell)
+          sh_p1              = gam%atoms(atom)%sh_p(shell)
+          sh_pn              = gam%atoms(atom)%sh_p(shell+1)-1
+          nc                 = sh_pn - sh_p1 + 1
+          sh_np(is,ind)      = nc
+          p_zet(1:nc,is,ind) = real(gam%atoms(atom)%p_zet(sh_p1:sh_pn),kind=kind(p_zet))
+          p_c  (1:nc,is,ind) = real(gam%atoms(atom)%p_c  (sh_p1:sh_pn),kind=kind(p_c))
+        end do copy_shells
+        !
+        !  Flag identical exponents for the primitives, and set up equivalence lists
+        !
+        p_master(  :,:,ind) = .true. ! Assume what all primitives are unique unless known otherwise
+        p_z_same(:,:,:,ind) = 0
+        p_c_max (  :,:,ind) = 0
+        coalesce_shells: do is=1,sh_ns(ind)
+          coalesce_primitives: do ip=1,sh_np(is,ind)
+            if (.not.p_master(ip,is,ind)) cycle coalesce_primitives
+            zref = p_zet(ip,is,ind)
+            !
+            !  We can assume what basis was constructed by a sane person, and
+            !  a primitive appears only once within a shell. Hence, we can
+            !  start scanning with the next shell
+            !
+            iso = is ; ipo = ip
+            p_c_max(ip,is,ind) = abs(p_c(ip,is,ind))
+            scan_shells: do is2=is+1,sh_ns(ind)
+              scan_primitives: do ip2=1,sh_np(is2,ind)
+                if (abs(p_zet(ip2,is2,ind)-zref)>10*spacing(zref)) cycle scan_primitives
+                !
+                !  This primitive was seen before; flag it, and add location of this
+                !  primitive to the chain
+                !
+                p_master(ip2,is2,ind) = .false.
+                p_z_same(:,ipo,iso,ind) = (/ is2, ip2 /)
+                iso = is2 ; ipo = ip2
+                p_c_max(ip,is,ind) = max(p_c_max(ip,is,ind),abs(p_c(ip2,is2,ind)))
+              end do scan_primitives
+            end do scan_shells
+            !
+          end do coalesce_primitives
+        end do coalesce_shells
+        !
+        !  A bit of printing
+        !
+        if (verbose>=2) then
+          write (out,"(/'Shell analysis, index = ',i1)") ind
+          write (out,"(1x,a8,1x,a8,1x,a12,1x,a12,1x,a8,1x,a8,1x,a8,1x,a12)") &
+                 ' Shell ', ' Primitive ', ' Exponent ', ' Contraction ', ' Master ', 'Same shl', 'Same prm', 'Max. contr.'
+          print_shells: do is=1,sh_ns(ind)
+            print_primitives: do ip=1,sh_np(is,ind)
+              write (out,"(1x,i8,1x,i8,1x,f12.5,1x,f12.5,1x,l8,1x,i8,1x,i8,1x,f12.5)") &
+                     is, ip, p_zet(ip,is,ind), p_c(ip,is,ind), p_master(ip,is,ind), p_z_same(:,ip,is,ind), p_c_max(ip,is,ind)
+            end do print_primitives
+            write (out,"()")
+          end do print_shells
+        end if
+      end subroutine fetch_batch
+!   end subroutine gamess_2e_integrals_real

--- a/import_gamess_os_1e_3c_common.f90
+++ b/import_gamess_os_1e_3c_common.f90
@@ -1,0 +1,74 @@
+!   subroutine os_1e_3c_real(what,p2_l,p2_r,n_rec,vb_p,r_l,z_l,r_r,z_r)
+!     type(gam_operator_data), intent(in) :: what             ! Operator parameters
+!     integer(ik), intent(in)  :: p2_l, p2_r, n_rec           ! Upper dimensions of the vb_p array
+!     real(rk), intent(out)    :: vb_p(0:p2_l,0:p2_r,0:n_rec) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)    :: r_l(:)                      ! Centre of the left b.f.
+!     real(ark), intent(in)    :: z_l                         ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)    :: r_r(:)                      ! ditto, for the right b.f.
+!     real(ark), intent(in)    :: z_r                         ! 
+!     !
+      real(kind(z_l)) :: zeta, p(3), c(3), s00, s, t
+      integer(ik)     :: l_l, l_r                            ! "Angular momentum" on the the left and right
+      integer(ik)     :: m_l, m_r, ic, id1, id2, id3, m_i
+      !
+      !  Sanity check: if the recursion order enough to reach the desided angular momentum?
+      !
+      l_l = sum(ang_nxyz(p2_l,:))
+      l_r = sum(ang_nxyz(p2_r,:))
+      if (n_rec/=l_l+l_r) stop 'import_gamess%os_1e_3c - called with an unreasonable order of recursion'
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,zeta=zeta,p=p,s00a=s00)
+      c = real(what%op_xyz,kind=kind(c))
+      !
+      !  Initialize primitive integrals. This is the only part which depends on the
+      !  specific operator; the recursions are identical for all kernels.
+      !
+      t = zeta * sum((p-c)**2)
+      call os_basic_integral(what,zeta,t,n_rec,vb_p(0,0,:))
+      !
+      !  (0|f(r)|0) integrals
+      !
+      vb_p(0,0,:) = s00 * vb_p(0,0,:)
+      ! write (out,"('Basic integrals = ',10g16.9)") vb_p(0,0,:)
+      !
+      !  (0|f(r)|n) integrals; special-case recursion.
+      !
+      right_bootstrap: do m_r=1,p2_r  ! S-functions (m_r=0) are already taken care of
+        l_r = sum(ang_nxyz(m_r,:))    ! Total "angular momentum" in the right function
+        find_right: do ic=1,3
+          id1 = drop_xyz(m_r,ic)
+          if (id1<0) cycle find_right
+          order_bootstrap: do m_i=0,n_rec-l_r
+            s = (p(ic)-r_r(ic)) * vb_p(0,id1,m_i) - (p(ic)-c(ic)) * vb_p(0,id1,m_i+1)
+            id2 = drop_xyz(id1,ic)
+            if (id2>=0) s = s + (ang_nxyz(id1,ic)/(2*zeta)) * (vb_p(0,id2,m_i) - vb_p(0,id2,m_i+1))
+            vb_p(0,m_r,m_i) = s
+            ! write (out,"(' set ',3i5,' to ',g16.9)") 0, m_r, m_i, s
+          end do order_bootstrap
+          exit find_right
+        end do find_right
+      end do right_bootstrap
+      !
+      !  Now the general case: always recurse on the left.
+      !
+      right_loop: do m_r=0,p2_r
+        l_r = sum(ang_nxyz(m_r,:))    ! Total "angular momentum" in the right function
+        left_recurrence: do m_l=1,p2_l
+          l_l = sum(ang_nxyz(m_l,:))    ! Total "angular momentum" in the left function
+          find_left: do ic=1,3
+            id1 = drop_xyz(m_l,ic)
+            if (id1<0) cycle find_left
+            order_loop: do m_i=0,n_rec-l_l-l_r
+              s = (p(ic)-r_l(ic)) * vb_p(id1,m_r,m_i) - (p(ic)-c(ic)) * vb_p(id1,m_r,m_i+1)
+              id2 = drop_xyz(id1,ic)
+              if (id2>=0) s = s + (ang_nxyz(id1,ic)/(2*zeta)) * (vb_p(id2,m_r,m_i) - vb_p(id2,m_r,m_i+1))
+              id3 = drop_xyz(m_r,ic)
+              if (id3>=0) s = s + (ang_nxyz(m_r,ic)/(2*zeta)) * (vb_p(id1,id3,m_i) - vb_p(id1,id3,m_i+1))
+              vb_p(m_l,m_r,m_i) = s
+              ! write (out,"(' set ',3i5,' to ',g16.9)") 0, m_r, m_i, s
+            end do order_loop
+            exit find_left
+          end do find_left
+        end do left_recurrence
+      end do right_loop
+!   end subroutine os_1e_3c_real

--- a/import_gamess_os_1e_3c_common.f90
+++ b/import_gamess_os_1e_3c_common.f90
@@ -5,7 +5,7 @@
 !     real(ark), intent(in)    :: r_l(:)                      ! Centre of the left b.f.
 !     real(ark), intent(in)    :: z_l                         ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)    :: r_r(:)                      ! ditto, for the right b.f.
-!     real(ark), intent(in)    :: z_r                         ! 
+!     real(ark), intent(in)    :: z_r                         !
 !     !
       real(kind(z_l)) :: zeta, p(3), c(3), s00, s, t
       integer(ik)     :: l_l, l_r                            ! "Angular momentum" on the the left and right

--- a/import_gamess_os_1e_contraction_common.f90
+++ b/import_gamess_os_1e_contraction_common.f90
@@ -6,9 +6,9 @@
 !     real(ark), intent(in)                :: z_l(:)  ! Primitive exponents on the left
 !     real(ark), intent(in)                :: c_l(:)  ! Contractions on the left
 !     real(ark), intent(in)                :: r_r(:)  ! Ditto on the right
-!     integer(ik), intent(in)              :: l_r     ! 
-!     real(ark), intent(in)                :: z_r(:)  ! 
-!     real(ark), intent(in)                :: c_r(:)  ! 
+!     integer(ik), intent(in)              :: l_r     !
+!     real(ark), intent(in)                :: z_r(:)  !
+!     real(ark), intent(in)                :: c_r(:)  !
       !
       integer(ik)                 :: ic_l, p1_l, p2_l, p_l, int_l
       integer(ik)                 :: ic_r, p1_r, p2_r, p_r, int_r

--- a/import_gamess_os_1e_contraction_common.f90
+++ b/import_gamess_os_1e_contraction_common.f90
@@ -1,0 +1,115 @@
+!   subroutine os_1e_contraction_real(what,vb,r_l,l_l,z_l,c_l,r_r,l_r,z_r,c_r)
+!     type (gam_operator_data), intent(in) :: what    ! Integral to evaluate
+!     real(rk), intent(out)                :: vb(:,:) ! Place for the integrals
+!     real(ark), intent(in)                :: r_l(:)  ! Coordinate on the left, in Bohr
+!     integer(ik), intent(in)              :: l_l     ! "Angular momentum" on the left
+!     real(ark), intent(in)                :: z_l(:)  ! Primitive exponents on the left
+!     real(ark), intent(in)                :: c_l(:)  ! Contractions on the left
+!     real(ark), intent(in)                :: r_r(:)  ! Ditto on the right
+!     integer(ik), intent(in)              :: l_r     ! 
+!     real(ark), intent(in)                :: z_r(:)  ! 
+!     real(ark), intent(in)                :: c_r(:)  ! 
+      !
+      integer(ik)                 :: ic_l, p1_l, p2_l, p_l, int_l
+      integer(ik)                 :: ic_r, p1_r, p2_r, p_r, int_r
+      real(kind(vb)), allocatable :: vb_r(:,:,:)  ! Buffer for recursions
+      real(kind(vb))              :: wgt
+      integer(ik)                 :: n_rec        ! Number of additional recursion intermediated
+      integer(ik)                 :: alloc
+      real(kind(vb))              :: ang_c_kind(lbound(ang_c,dim=1):ubound(ang_c,dim=1))
+      !
+      p1_l = ang_loc(l_l)
+      p2_l = ang_loc(l_l+1)-1
+      p1_r = ang_loc(l_r)
+      p2_r = ang_loc(l_r+1)-1
+      !
+      select case (what%op_name)
+        case default
+          !
+          !  Assume general 3-centre integral; each unit of angular momentum requires
+          !  an extra order in recursion.
+          !
+          n_rec = l_l + l_r
+        case ('OVERLAP')
+          n_rec = 0
+        case ('DIPOLE X','DIPOLE Y','DIPOLE Z','KINETIC','D/DX','D/DY','D/DZ')
+          n_rec = 1
+        case ('R-D/DR')
+          n_rec = 2
+      end select
+      allocate (vb_r(0:p2_l,0:p2_r,0:n_rec),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('import_gamess%os_1e_contraction: allocation failed. Parameters are:',3(1x,i8))") p2_l, p2_r, n_rec
+        stop 'import_gamess%os_1e_contraction: Buffer allocation failed'
+      end if
+      !
+      vb = 0
+      ang_c_kind = real(ang_c,kind=kind(ang_c_kind))
+      r_contractions_loop: do ic_r=1,size(z_r)
+        l_contractions_loop: do ic_l=1,size(z_l)
+          !*ps
+          ! write (out,"('doing contraction ',2i3,' c = ',2g13.6)") ic_l, ic_r, c_l(ic_l), c_r(ic_r)
+          ! write (out,"('p2 = '2i4,' r_l = ',3f12.5,' l_l = ',i2,' z_l = ',g12.6,' r_r = ',3f12.5,' l_r = ',i2,' z_r = ',g12.6)") &
+          !        p2_l,p2_r,r_l,l_l,z_l(ic_l),r_r,l_r,z_r(ic_r)
+          !
+          !  The only part of the 1e integral code which is property-specific
+          !  is the primitive-integral call below. Everything else is identical
+          !  for all properties.
+          !
+          select case (what%op_name)
+            case default
+              write (out,"('import_gamess%os_1e_contraction: Property ',a,' is not implemented')") trim(what%op_name)
+              stop 'import_gamess%os_1e_contraction: Unimplemented property'
+            case ('OVERLAP')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('DIPOLE X')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_dipole (1_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('DIPOLE Y')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_dipole (2_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('DIPOLE Z')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_dipole (3_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('D/DX')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_grad   (1_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('D/DY')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_grad   (2_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('D/DZ')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_grad   (3_ik,vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('R-D/DR')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,2),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_dipole (what%op_i, &
+                                      vb_r(:,:,2),p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_rddr   (what%op_i,what%op_j, &
+                          vb_r(:,:,2),vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('KINETIC')
+              call os_1e_overlap(                 p2_l,p2_r,vb_r(:,:,1),r_l,z_l(ic_l),r_r,z_r(ic_r))
+              call os_1e_kinetic(     vb_r(:,:,1),p2_l,p2_r,vb_r(:,:,0),r_l,z_l(ic_l),r_r,z_r(ic_r))
+            case ('3C 1/R','3C DELTA','3C ONE','3C R','3C R**2','3C GAUSS', &
+                  '3C GAUSS ONE', '3C GAUSS R', '3C A/(R**2+A**2)', '3C R/(R**2+A**2)')
+              call os_1e_3c(what,p2_l,p2_r,n_rec,vb_r,r_l,z_l(ic_l),r_r,z_r(ic_r))
+          end select
+          !
+          wgt = c_l(ic_l) * c_r(ic_r)
+          r_accumulate: do p_r=p1_r,p2_r
+            int_r = p_r - p1_r + 1
+            l_accumulate: do p_l=p1_l,p2_l
+              int_l = p_l - p1_l + 1
+              vb(int_l,int_r) = vb(int_l,int_r) + wgt*ang_c_kind(p_l)*ang_c_kind(p_r)*vb_r(p_l,p_r,0)
+              !*ps
+              ! write (out,"(' int ',2i4,' increased by ',f12.6)") int_l, int_r, wgt*ang_c(p_l)*ang_c(p_r)*vb_p(p_l,p_r)
+            end do l_accumulate
+          end do r_accumulate
+          !
+        end do l_contractions_loop
+      end do r_contractions_loop
+      !
+      deallocate (vb_r,stat=alloc)
+      if (alloc/=0) then
+        stop 'import_gamess%os_1e_contraction: Buffer deallocation failed'
+      end if
+!   end subroutine os_1e_contraction_real

--- a/import_gamess_os_1e_dipole_common.f90
+++ b/import_gamess_os_1e_dipole_common.f90
@@ -6,7 +6,7 @@
 !     real(ark), intent(in)    :: r_l(:)             ! Centre of the left b.f.
 !     real(ark), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
-!     real(ark), intent(in)    :: z_r                ! 
+!     real(ark), intent(in)    :: z_r                !
       !
       real(kind(z_l)) :: zeta, xi, p(3), s00, s
       integer(ik)     :: m_l, m_r, ic, id1, id2, id3
@@ -33,7 +33,7 @@
         end do find_right
       end do right_bootstrap
       !
-      !  Now the general case: always recurse on the left. This is the 
+      !  Now the general case: always recurse on the left. This is the
       !                        full eq. A7 of Obara-Saika
       !
       right_loop: do m_r=0,p2_r

--- a/import_gamess_os_1e_dipole_common.f90
+++ b/import_gamess_os_1e_dipole_common.f90
@@ -1,0 +1,55 @@
+!   subroutine os_1e_dipole_real(id,vb_s,p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r)
+!     integer(ik), intent(in) :: id                  ! Dipole component to evaluate
+!     integer(ik), intent(in) :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+!     real(rk), intent(in)    :: vb_s(0:p2_l,0:p2_r) ! Buffer containing primitive overlaps
+!     real(rk), intent(out)   :: vb_p(0:p2_l,0:p2_r) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)    :: r_l(:)             ! Centre of the left b.f.
+!     real(ark), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
+!     real(ark), intent(in)    :: z_r                ! 
+      !
+      real(kind(z_l)) :: zeta, xi, p(3), s00, s
+      integer(ik)     :: m_l, m_r, ic, id1, id2, id3
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,xi=xi,zeta=zeta,p=p,s00=s00)
+      !
+      !*ps
+      ! write (out,"('   xi = ',g12.6,' zeta = ',g12.6,' p = ',3f13.6,' s00 = ',g12.6)") xi, zeta, p, s00
+      !
+      !  Bootstrap: calculate all overlaps on the right, keeping left
+      !             at zero. This is a special case of eq. A7
+      !
+      vb_p(0,0) = p(id)*s00
+      right_bootstrap: do m_r=1,p2_r
+        find_right: do ic=1,3
+          id1 = drop_xyz(m_r,ic)
+          if (id1<0) cycle find_right
+          s = (p(ic)-r_r(ic)) * vb_p(0,id1)
+          id2 = drop_xyz(id1,ic)
+          if (id2>=0) s = s + vb_p(0,id2)*ang_nxyz(id1,ic)/(2*zeta)
+          if (ic==id) s = s + vb_s(0,id1)/(2*zeta)
+          vb_p(0,m_r) = s
+          exit find_right
+        end do find_right
+      end do right_bootstrap
+      !
+      !  Now the general case: always recurse on the left. This is the 
+      !                        full eq. A7 of Obara-Saika
+      !
+      right_loop: do m_r=0,p2_r
+        left_recurrence: do m_l=1,p2_l
+          find_left: do ic=1,3
+            id1 = drop_xyz(m_l,ic)
+            if (id1<0) cycle find_left
+            s = (p(ic)-r_l(ic)) * vb_p(id1,m_r)
+            id2 = drop_xyz(id1,ic)
+            if (id2>=0) s = s + vb_p(id2,m_r)*ang_nxyz(id1,ic)/(2*zeta)
+            id3 = drop_xyz(m_r,ic)
+            if (id3>=0) s = s + vb_p(id1,id3)*ang_nxyz(m_r,ic)/(2*zeta)
+            if (ic==id) s = s + vb_s(id1,m_r)/(2*zeta)
+            vb_p(m_l,m_r) = s
+            exit find_left
+          end do find_left
+        end do left_recurrence
+      end do right_loop
+!   end subroutine os_1e_dipole_real

--- a/import_gamess_os_1e_grad_common.f90
+++ b/import_gamess_os_1e_grad_common.f90
@@ -1,0 +1,26 @@
+!   subroutine os_1e_grad_real(ic,vb_s,p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r)
+!     integer(ik), intent(in) :: ic                  ! Gradient component to evaluate
+!     integer(ik), intent(in) :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+!     real(rk), intent(in)    :: vb_s(0:p2_l,0:p2_r) ! Buffer containing primitive overlaps
+!     real(rk), intent(out)   :: vb_p(0:p2_l,0:p2_r) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
+!     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
+!     real(ark), intent(in)   :: z_r                 ! 
+      !
+      real(kind(z_l)) :: zeta, p(3), s
+      integer(ik)     :: m_l, m_r, id1, id2
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,zeta=zeta,p=p)
+      !
+      right: do m_r=0,p2_r
+        left: do m_l=0,p2_l
+          s = -2*z_r*(p(ic)-r_r(ic)) * vb_s(m_l,m_r)
+          id1 = drop_xyz(m_r,ic)
+          if (id1>=0) s = s + (ang_nxyz(m_r,ic)*z_l/zeta) * vb_s(m_l,id1)
+          id2 = drop_xyz(m_l,ic)
+          if (id2>=0) s = s - (ang_nxyz(m_l,ic)*z_r/zeta) * vb_s(id2,m_r)
+          vb_p(m_l,m_r) = s
+        end do left
+      end do right
+!   end subroutine os_1e_grad_real

--- a/import_gamess_os_1e_grad_common.f90
+++ b/import_gamess_os_1e_grad_common.f90
@@ -6,7 +6,7 @@
 !     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
 !     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-!     real(ark), intent(in)   :: z_r                 ! 
+!     real(ark), intent(in)   :: z_r                 !
       !
       real(kind(z_l)) :: zeta, p(3), s
       integer(ik)     :: m_l, m_r, id1, id2

--- a/import_gamess_os_1e_kinetic_common.f90
+++ b/import_gamess_os_1e_kinetic_common.f90
@@ -5,7 +5,7 @@
 !     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
 !     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-!     real(ark), intent(in)   :: z_r                 ! 
+!     real(ark), intent(in)   :: z_r                 !
 !     !
       real(kind(z_l)) :: zeta, xi, p(3), s00, s
       integer(ik)     :: m_l, m_r, ic, id1, id2, id3
@@ -35,7 +35,7 @@
         end do find_right
       end do right_bootstrap
       !
-      !  Now the general case: always recurse on the left. This is the 
+      !  Now the general case: always recurse on the left. This is the
       !                        full eq. A12 of Obara-Saika
       !
       right_loop: do m_r=0,p2_r

--- a/import_gamess_os_1e_kinetic_common.f90
+++ b/import_gamess_os_1e_kinetic_common.f90
@@ -1,0 +1,62 @@
+!   subroutine os_1e_kinetic_real(vb_s,p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r)
+!     integer(ik), intent(in) :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+!     real(rk), intent(in)    :: vb_s(0:p2_l,0:p2_r) ! Buffer containing primitive overlaps
+!     real(rk), intent(out)   :: vb_p(0:p2_l,0:p2_r) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
+!     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
+!     real(ark), intent(in)   :: z_r                 ! 
+!     !
+      real(kind(z_l)) :: zeta, xi, p(3), s00, s
+      integer(ik)     :: m_l, m_r, ic, id1, id2, id3
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,xi=xi,zeta=zeta,p=p,s00=s00)
+      !
+      !  S-S kinetic energy; O&S eq. A13
+      !
+      vb_p(0,0) = xi*(3-2*xi*sum((r_l-r_r)**2))*s00
+      !
+      !  Bootstrap: calculate all overlaps on the right, keeping left
+      !             at zero. This is a special case of eq. A12
+      !
+      right_bootstrap: do m_r=1,p2_r
+        find_right: do ic=1,3
+          id1 = drop_xyz(m_r,ic)
+          if (id1<0) cycle find_right
+          id2 = drop_xyz(id1,ic)
+          s = (p(ic)-r_r(ic)) * vb_p(0,id1)
+          s = s + 2*xi * vb_s(0,m_r)
+          if (id2>=0) then
+            s = s + (ang_nxyz(id1,ic)/(2*zeta)) * vb_p(0,id2)
+            s = s - (xi/z_r)*ang_nxyz(id1,ic) * vb_s(0,id2)
+          end if
+          vb_p(0,m_r) = s
+          exit find_right
+        end do find_right
+      end do right_bootstrap
+      !
+      !  Now the general case: always recurse on the left. This is the 
+      !                        full eq. A12 of Obara-Saika
+      !
+      right_loop: do m_r=0,p2_r
+        left_recurrence: do m_l=1,p2_l  ! m_l=0 is already done
+          find_left: do ic=1,3
+            id1 = drop_xyz(m_l,ic)
+            if (id1<0) cycle find_left
+            id2 = drop_xyz(id1,ic)
+            id3 = drop_xyz(m_r,ic)
+            s = (p(ic)-r_l(ic)) * vb_p(id1,m_r)
+            s = s + 2*xi * vb_s(m_l,m_r)
+            if (id2>=0) then
+              s = s + (ang_nxyz(id1,ic)/(2*zeta)) * vb_p(id2,m_r)
+              s = s - (xi/z_l)*ang_nxyz(id1,ic) * vb_s(id2,m_r)
+            end if
+            if (id3>=0) then
+              s = s + (ang_nxyz(m_r,ic)/(2*zeta)) * vb_p(id1,id3)
+            end if
+            vb_p(m_l,m_r) = s
+            exit find_left
+          end do find_left
+        end do left_recurrence
+      end do right_loop
+!   end subroutine os_1e_kinetic_real

--- a/import_gamess_os_1e_matrix_common.f90
+++ b/import_gamess_os_1e_matrix_common.f90
@@ -16,7 +16,7 @@
       !  Iterate over all shell blocks. Since l and r are not necessarily the same,
       !  matrix elements do not have to be symmetric, and we have to process all
       !  shell blocks explicitly.
-      ! 
+      !
       p1_r = 1
       r_atom_loop: do at_r=1,r%natoms
         r_shell_loop: do sh_r=1,r%atoms(at_r)%nshell

--- a/import_gamess_os_1e_matrix_common.f90
+++ b/import_gamess_os_1e_matrix_common.f90
@@ -1,0 +1,69 @@
+!   subroutine os_1e_matrix_real(what,l,r,v)
+!     type (gam_operator_data), intent(in) :: what   ! Operator to evaluate
+!     type (gam_structure), intent(in)     :: l      ! Basis set on the left
+!     type (gam_structure), intent(in)     :: r      ! Basis set on the right
+!     real(rk), intent(out)                :: v(:,:) ! Buffer for the integrals
+      !
+      integer(ik)  :: at_l, sh_l, c1_l, c2_l, l_l, p1_l, p2_l
+      integer(ik)  :: at_r, sh_r, c1_r, c2_r, l_r, p1_r, p2_r
+      !
+      !  Make sure neither bra nor ket include a rotation matrix
+      !
+      if (.not. MathIsUnitMatrix(l%rotmat) .or. .not. MathIsUnitMatrix(r%rotmat) ) then
+        stop 'import_gamess%os_1e_matrix - rotation is not implemented'
+      end if
+      !
+      !  Iterate over all shell blocks. Since l and r are not necessarily the same,
+      !  matrix elements do not have to be symmetric, and we have to process all
+      !  shell blocks explicitly.
+      ! 
+      p1_r = 1
+      r_atom_loop: do at_r=1,r%natoms
+        r_shell_loop: do sh_r=1,r%atoms(at_r)%nshell
+          !
+          !  Get "angular momentum" (this is a Cartesian shell, so not really)
+          !  and the block length.
+          !
+          l_r  = r%atoms(at_r)%sh_l(sh_r)
+          p2_r = p1_r + ang_loc(l_r+1) - ang_loc(l_r) - 1
+          !
+          !  Figure out the range of contractions for this shell
+          !
+          c1_r = r%atoms(at_r)%sh_p(sh_r  )
+          c2_r = r%atoms(at_r)%sh_p(sh_r+1)-1
+          p1_l = 1
+          l_atom_loop: do at_l=1,l%natoms
+            l_shell_loop: do sh_l=1,l%atoms(at_l)%nshell
+              l_l  = l%atoms(at_l)%sh_l(sh_l)
+              p2_l = p1_l + ang_loc(l_l+1) - ang_loc(l_l) - 1
+              c1_l = l%atoms(at_l)%sh_p(sh_l  )
+              c2_l = l%atoms(at_l)%sh_p(sh_l+1)-1
+              !*ps
+              ! write (out,"('doing pair: ',2i4,' shells: ',2i4,' block: ',4i6)") at_l, at_r, sh_l, sh_r, p1_l, p2_l, p1_r, p2_r
+              ! write (out,"('atoms at:  '6f12.6)") l%atoms(at_l)%xyz/abohr, r%atoms(at_r)%xyz/abohr
+              ! write (out,"('l: ',2i2)") l_l, l_r
+              ! write (out,"('zeta_l: ',12g12.6)") l%atoms(at_l)%p_zet(c1_l:c2_l)
+              ! write (out,"('zeta_r: ',12g12.6)") r%atoms(at_r)%p_zet(c1_r:c2_r)
+              ! write (out,"('   c_l: ',12g12.6)") l%atoms(at_l)%p_c(c1_l:c2_l)
+              ! write (out,"('   c_r: ',12g12.6)") r%atoms(at_r)%p_c(c1_r:c2_r)
+              call os_1e_contraction(what,v(p1_l:p2_l,p1_r:p2_r),        &
+                   real(l%atoms(at_l)%xyz,kind=kind(v))/abohr,l_l,       &
+                     real(l%atoms(at_l)%p_zet(c1_l:c2_l),kind=kind(v)),  &
+                       real(l%atoms(at_l)%p_c(c1_l:c2_l),kind=kind(v)),  &
+                   real(r%atoms(at_r)%xyz,kind=kind(v))/abohr,l_r,       &
+                     real(r%atoms(at_r)%p_zet(c1_r:c2_r),kind=kind(v)),  &
+                       real(r%atoms(at_r)%p_c(c1_r:c2_r),kind=kind(v)))
+              p1_l = p2_l + 1
+            end do l_shell_loop
+          end do l_atom_loop
+          if (p1_l-1/=l%nbasis) then
+            stop 'import_gamess%os_1e_matrix - count error (l)'
+          end if
+          p1_r = p2_r + 1
+        end do r_shell_loop
+      end do r_atom_loop
+      !
+      if (p1_r-1/=r%nbasis) then
+        stop 'import_gamess%os_1e_matrix - count error (r)'
+      end if
+!   end subroutine os_1e_matrix_real

--- a/import_gamess_os_1e_overlap_common.f90
+++ b/import_gamess_os_1e_overlap_common.f90
@@ -1,0 +1,51 @@
+!   subroutine os_1e_overlap_real(p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r)
+!     integer(ik), intent(in) :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+!     real(rk), intent(out)   :: vb_p(0:p2_l,0:p2_r) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)    :: r_l(:)             ! Centre of the left b.f.
+!     real(ark), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
+!     real(ark), intent(in)    :: z_r                ! 
+      !
+      real(kind(z_l)) :: zeta, xi, p(3), s00, s
+      integer(ik) :: m_l, m_r, ic, id1, id2, id3
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,xi=xi,zeta=zeta,p=p,s00=s00)
+      !
+      !*ps
+      ! write (out,"('   xi = ',g12.6,' zeta = ',g12.6,' p = ',3f13.6,' s00 = ',g12.6)") xi, zeta, p, s00
+      !
+      !  Bootstrap: calculate all overlaps on the right, keeping left
+      !             at zero. This is a special case of eq. A2
+      !
+      vb_p(0,0) = s00
+      right_bootstrap: do m_r=1,p2_r
+        find_right: do ic=1,3
+          id1 = drop_xyz(m_r,ic)
+          if (id1<0) cycle find_right
+          s = (p(ic)-r_r(ic)) * vb_p(0,id1)
+          id2 = drop_xyz(id1,ic)
+          if (id2>=0) s = s + vb_p(0,id2)*ang_nxyz(id1,ic)/(2*zeta)
+          vb_p(0,m_r) = s
+          exit find_right
+        end do find_right
+      end do right_bootstrap
+      !
+      !  Now the general case: always recurse on the left. This is the 
+      !                        full eq. A2 of Obara-Saika
+      !
+      right_loop: do m_r=0,p2_r
+        left_recurrence: do m_l=1,p2_l
+          find_left: do ic=1,3
+            id1 = drop_xyz(m_l,ic)
+            if (id1<0) cycle find_left
+            s = (p(ic)-r_l(ic)) * vb_p(id1,m_r)
+            id2 = drop_xyz(id1,ic)
+            if (id2>=0) s = s + vb_p(id2,m_r)*ang_nxyz(id1,ic)/(2*zeta)
+            id3 = drop_xyz(m_r,ic)
+            if (id3>=0) s = s + vb_p(id1,id3)*ang_nxyz(m_r,ic)/(2*zeta)
+            vb_p(m_l,m_r) = s
+            exit find_left
+          end do find_left
+        end do left_recurrence
+      end do right_loop
+!   end subroutine os_1e_overlap_real

--- a/import_gamess_os_1e_overlap_common.f90
+++ b/import_gamess_os_1e_overlap_common.f90
@@ -4,7 +4,7 @@
 !     real(ark), intent(in)    :: r_l(:)             ! Centre of the left b.f.
 !     real(ark), intent(in)    :: z_l                ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)    :: r_r(:)             ! ditto, for the right b.f.
-!     real(ark), intent(in)    :: z_r                ! 
+!     real(ark), intent(in)    :: z_r                !
       !
       real(kind(z_l)) :: zeta, xi, p(3), s00, s
       integer(ik) :: m_l, m_r, ic, id1, id2, id3
@@ -30,7 +30,7 @@
         end do find_right
       end do right_bootstrap
       !
-      !  Now the general case: always recurse on the left. This is the 
+      !  Now the general case: always recurse on the left. This is the
       !                        full eq. A2 of Obara-Saika
       !
       right_loop: do m_r=0,p2_r

--- a/import_gamess_os_1e_rddr_common.f90
+++ b/import_gamess_os_1e_rddr_common.f90
@@ -1,0 +1,29 @@
+!   subroutine os_1e_rddr_real(ic,jc,vb_s,vb_d,p2_l,p2_r,vb_p,r_l,z_l,r_r,z_r)
+!     integer(ik), intent(in) :: ic                  ! Component of the dipole operator
+!     integer(ik), intent(in) :: jc                  ! Component of the derivative operator
+!     integer(ik), intent(in) :: p2_l, p2_r          ! Upper dimensions of the vb_p array
+!     real(rk), intent(in)    :: vb_s(0:p2_l,0:p2_r) ! Buffer containing primitive overlaps
+!     real(rk), intent(in)    :: vb_d(0:p2_l,0:p2_r) ! Buffer containing primitive dipole matrix elements
+!     real(rk), intent(out)   :: vb_p(0:p2_l,0:p2_r) ! Buffer used for recurrences, and the final result
+!     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
+!     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
+!     real(ark), intent(in)   :: z_r                 ! 
+!     !
+      real(kind(z_l)) :: zeta, p(3), s
+      integer(ik)     :: m_l, m_r, idl, idr
+      !
+      call os_common_primitives(r_l,z_l,r_r,z_r,zeta=zeta,p=p)
+      !
+      right: do m_r=0,p2_r
+        left: do m_l=0,p2_l
+          s = -2*z_r*(p(jc)-r_r(jc)) * vb_d(m_l,m_r)
+          idr = drop_xyz(m_r,jc)
+          if (idr>=0) s = s + (ang_nxyz(m_r,jc)*z_l/zeta) * vb_d(m_l,idr)
+          idl = drop_xyz(m_l,jc)
+          if (idl>=0) s = s - (ang_nxyz(m_l,jc)*z_r/zeta) * vb_d(idl,m_r)
+          if (jc==ic) s = s - (z_r/zeta) * vb_s(m_l,m_r)
+          vb_p(m_l,m_r) = s
+        end do left
+      end do right
+!   end subroutine os_1e_rddr_real

--- a/import_gamess_os_1e_rddr_common.f90
+++ b/import_gamess_os_1e_rddr_common.f90
@@ -8,7 +8,7 @@
 !     real(ark), intent(in)   :: r_l(:)              ! Centre of the left b.f.
 !     real(ark), intent(in)   :: z_l                 ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)   :: r_r(:)              ! ditto, for the right b.f.
-!     real(ark), intent(in)   :: z_r                 ! 
+!     real(ark), intent(in)   :: z_r                 !
 !     !
       real(kind(z_l)) :: zeta, p(3), s
       integer(ik)     :: m_l, m_r, idl, idr

--- a/import_gamess_os_2e_batch_common.f90
+++ b/import_gamess_os_2e_batch_common.f90
@@ -26,7 +26,7 @@
       real(kind(v)), allocatable  :: vb_r(:,:,:,:,:) ! Buffer for recursion
       real(kind(v))               :: wgt
       real(kind(v))               :: zet(4)          ! Primitive exponents
-      real(kind(v))               :: w_cut           ! Absolute cutoff 
+      real(kind(v))               :: w_cut           ! Absolute cutoff
       logical                     :: zero_primitives ! True if all primitive integrals are negligible
       real(kind(v))               :: ang_c_kind(lbound(ang_c,dim=1):ubound(ang_c,dim=1))
       !

--- a/import_gamess_os_2e_batch_common.f90
+++ b/import_gamess_os_2e_batch_common.f90
@@ -1,0 +1,176 @@
+!   subroutine os_2e_batch_real(what,v,xyz,sh_l,sh_ns,sh_np,p_zet,p_c,p_c_max,p_master,p_z_same,cutoff_2e)
+!     type(gam_operator_data), intent(in) :: what              ! Operator parameters
+!     real(rk), intent(out)               :: v(:,:,:,:)        ! Buffer for the results
+!     real(ark), intent(in)               :: xyz(:,:)          ! Coordinates of the basis functions within each batch
+!     integer(ik), intent(in)             :: sh_l (:)          ! Angular momentum of each shell within a batch is the same
+!     integer(ik), intent(in)             :: sh_ns(:)          ! Number of shells in each batch
+!     integer(ik), intent(in)             :: sh_np(:,:)        ! Number of primitives in each shell
+!     real(ark), intent(in)               :: p_zet   (:,:,:)   ! Primitive exponents in each shell
+!     real(ark), intent(in)               :: p_c     (:,:,:)   ! Primitive contraction coefficients in each shell
+!     real(ark), intent(in)               :: p_c_max (:,:,:)   ! Absolute maximum of a contraction coefficient for all instances
+!                                                              ! of a primitive. This value is only defined for the "master" entry
+!     logical, intent(in)                 :: p_master(:,:,:)   ! "Master" copy of the exponent
+!     integer(ik), intent(in)             :: p_z_same(:,:,:,:) ! Next contraction with an identical exponent
+!                                                              ! First index: 1 = shell index; 2 = contraction within shell
+!                                                              ! 2nd, 3rd, and 4th indices are as the 1st etc in p_zet/p_c/p_master
+!     real(rk), intent(in)                :: cutoff_2e         ! Absolute accuracy required in the final integrals;
+!                                                              ! Negative means retain full accuracy
+!     !
+      integer(ik)                 :: a, b, c, d      ! shell index within a batch
+      integer(ik)                 :: i, j, k, l      ! primitive index within a shell
+      integer(ik)                 :: p1(4)           ! Starting position of the desired block of primitive integrals
+      integer(ik)                 :: p2(4)           ! Ending position of the desired block of primitive integrals
+      integer(ik)                 :: sz(4)           ! Size of the desired block
+      integer(ik)                 :: nrec            ! Maximum recursion order
+      integer(ik)                 :: alloc           ! Allocation status, what else?
+      real(kind(v)), allocatable  :: vb_r(:,:,:,:,:) ! Buffer for recursion
+      real(kind(v))               :: wgt
+      real(kind(v))               :: zet(4)          ! Primitive exponents
+      real(kind(v))               :: w_cut           ! Absolute cutoff 
+      logical                     :: zero_primitives ! True if all primitive integrals are negligible
+      real(kind(v))               :: ang_c_kind(lbound(ang_c,dim=1):ubound(ang_c,dim=1))
+      !
+      !  Prepare angular factors of the right kind
+      !
+      ang_c_kind = real(ang_c,kind=kind(ang_c_kind))
+      !
+      !  All shells within the batch have the same angular momentum, so that the recursion buffer
+      !  does not have to be resized.
+      !
+      p1   = ang_loc(sh_l)
+      p2   = ang_loc(sh_l+1)-1
+      sz   = p2-p1+1
+      nrec = sum(sh_l)
+      allocate (vb_r(0:p2(1),0:p2(2),0:p2(3),0:p2(4),0:nrec),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('import_gamess%os_2e_batch: allocation failed with code ',i10,'. p2, nrec = ',5i8)") alloc, p2, nrec
+        stop 'import_gamess%os_2e_batch: Buffer deallocation failed'
+      end if
+      !
+      !  Figure out the cut-off point for the primitives; we need to include the angular
+      !  scaling factors since these can vary by nearly an order of magnitude.
+      !  The last angular scaling coefficient in a batch is always the largest one.
+      !
+      w_cut = cutoff_2e / product(ang_c_kind(p2))
+      !
+      v = 0
+      !
+      !  We do not want to process any of the primitives more than once; hence this
+      !  very complicated loop. It gets even worse during accumulation phase ...
+      !
+      contraction_1s: do a=1,sh_ns(1)
+        contraction_1p: do i=1,sh_np(a,1)
+          if (.not.p_master(i,a,1)) cycle contraction_1p ! Will be handled elsewhere
+          zet(1) = p_zet(i,a,1)
+          contraction_2s: do b=1,sh_ns(2)
+            contraction_2p: do j=1,sh_np(b,2)
+              if (.not.p_master(j,b,2)) cycle contraction_2p ! Will be handled elsewhere
+              zet(2) = p_zet(j,b,2)
+              contraction_3s: do c=1,sh_ns(3)
+                contraction_3p: do k=1,sh_np(c,3)
+                  if (.not.p_master(k,c,3)) cycle contraction_3p ! Will be handled elsewhere
+                  zet(3) = p_zet(k,c,3)
+                  contraction_4s: do d=1,sh_ns(4)
+                    contraction_4p: do l=1,sh_np(d,4)
+                      if (.not.p_master(l,d,4)) cycle contraction_4p ! Will be handled elsewhere
+                      zet(4) = p_zet(l,d,4)
+                      wgt    = p_c_max(i,a,1)*p_c_max(j,b,2)*p_c_max(k,c,3)*p_c_max(l,d,4)
+                      call os_2e_primitives(what,xyz,zet,p2,nrec,vb_r,w_cut/wgt,zero_primitives)
+                      if (zero_primitives) cycle contraction_4p
+                      call accumulate_all
+                    end do contraction_4p
+                  end do contraction_4s
+                end do contraction_3p
+              end do contraction_3s
+            end do contraction_2p
+          end do contraction_2s
+        end do contraction_1p
+      end do contraction_1s
+      !
+      deallocate (vb_r,stat=alloc)
+      if (alloc/=0) then
+        stop 'import_gamess%os_2e_batch: Buffer deallocation failed'
+      end if
+      !
+      contains
+      !
+      !  Accumulate contibution of these primitives to all contractions containing them
+      !
+      subroutine accumulate_all
+        integer(ik)   :: ea, eb, ec, ed ! "Equivalent" shell indices
+        integer(ik)   :: ei, ej, ek, el ! "Equivalent" contraction indices
+        integer(ik)   :: pi, pj, pk, pl ! Position of the contacted shell within the output buffer
+        real(kind(v)) :: ca, cb, cc, cd ! Contraction coefficients
+        real(kind(v)) :: wgt
+        !
+        !  We have to work through all instances of this primitive. We know there is
+        !  at least one instance, but there could be more ...
+        !
+        ea = a ; ei = i
+        primitive_1: do while (ea/=0)
+          ca = p_c(ei,ea,1)
+          pi = (ea-1)*sz(1) + 1
+          eb = b ; ej = j
+          primitive_2: do while (eb/=0)
+            cb = p_c(ej,eb,2)
+            pj = (eb-1)*sz(2) + 1
+            ec = c ; ek = k
+            primitive_3: do while (ec/=0)
+              cc = p_c(ek,ec,3)
+              pk = (ec-1)*sz(3) + 1
+              ed = d ; el = l
+              primitive_4: do while (ed/=0)
+                cd = p_c(el,ed,4)
+                pl = (ed-1)*sz(4) + 1
+                wgt = ca*cb*cc*cd
+                call accumulate(pi,pj,pk,pl,wgt)
+                call next_instance(ed,el,4_ik)
+              end do primitive_4
+              call next_instance(ec,ek,3_ik)
+            end do primitive_3
+            call next_instance(eb,ej,2_ik)
+          end do primitive_2
+          call next_instance(ea,ei,1_ik)
+        end do primitive_1
+      end subroutine accumulate_all
+      !
+      subroutine next_instance(shell,primitive,ind)
+        integer(ik), intent(inout) :: shell     ! Shell index within a batch
+        integer(ik), intent(inout) :: primitive ! Primitive index within a shell
+        integer(ik), intent(in)    :: ind       ! Centre index
+        !
+        integer(ik) :: a, i
+        !
+        a = shell ; i = primitive
+        if (a<=0 .or. a>sh_ns  (ind)) stop 'import_gamess%os_2e_batch%next_instance - bad shell index'
+        if (i<=0 .or. i>sh_np(a,ind)) stop 'import_gamess%os_2e_batch%next_instance - bad primitive index'
+        !
+        shell     = p_z_same(1,i,a,ind)
+        primitive = p_z_same(2,i,a,ind)
+      end subroutine next_instance
+      !
+      !  Accumulate contibution of these primitives to a single contaction
+      !
+      subroutine accumulate(pi,pj,pk,pl,wgt)
+        integer(ik), intent(in)   :: pi, pj, pk, pl ! Starting positions within output buffer
+        real(kind(v)), intent(in) :: wgt            ! Weight of this primitive
+        !
+        integer(ik) :: ip, jp, kp, lp  ! Indices within the recursion buffer
+        integer(ik) :: iq, jq, kq, lq  ! Indices within the output buffer
+        !
+        add_1: do ip=p1(1),p2(1)
+          iq = pi + ip - p1(1)
+          add_2: do jp=p1(2),p2(2)
+            jq = pj + jp - p1(2)
+            add_3: do kp=p1(3),p2(3)
+              kq = pk + kp - p1(3)
+              add_4: do lp=p1(4),p2(4)
+                lq = pl + lp - p1(4)
+                v(iq,jq,kq,lq) = v(iq,jq,kq,lq) &
+                               + wgt*ang_c_kind(ip)*ang_c_kind(jp)*ang_c_kind(kp)*ang_c_kind(lp) * vb_r(ip,jp,kp,lp,0)
+              end do add_4
+            end do add_3
+          end do add_2
+        end do add_1
+      end subroutine accumulate
+!   end subroutine os_2e_batch_real

--- a/import_gamess_os_2e_primitives_common.f90
+++ b/import_gamess_os_2e_primitives_common.f90
@@ -20,7 +20,7 @@
       real(kind(vb)) :: gf_tmp
       !
       ! There is a lot of overlap between formulae below and os_common_primitives()
-      ! 
+      !
       zeta = zet(1) + zet(2)                                        ! Ahlrichs eq. 3
       eta  = zet(3) + zet(4)                                        ! ... ditto
       rho  = zeta * eta / (zeta + eta)                              ! ... ditto
@@ -79,7 +79,7 @@
         call get_parent(i,ic,id1)
         il = sum(ang_nxyz(i,:))
         boot_i_order: do m=0,nrec-il
-            s = (p(ic)-xyz(ic,1)) * vb(id1,0,0,0,m) 
+            s = (p(ic)-xyz(ic,1)) * vb(id1,0,0,0,m)
             s = s - (rho/zeta) * (p(ic)-q(ic)) * vb(id1,0,0,0,m+1)
             id2 = drop_xyz(id1,ic)
             if (id2>=0) then

--- a/import_gamess_os_2e_primitives_common.f90
+++ b/import_gamess_os_2e_primitives_common.f90
@@ -1,0 +1,199 @@
+!   subroutine os_2e_primitives_real(what,xyz,zet,p2,nrec,vb,w_cut,zero)
+!     type(gam_operator_data), intent(in) :: what        ! Operator parameters
+!     real(ark), intent(in)               :: xyz(:,:)    ! Coordinates of the basis functions within each batch
+!     real(rk), intent(in)                :: zet  (:)    ! Primitive exponents
+!     integer(ik), intent(in)             :: p2   (:)    ! Ending position of the desired block of integrals
+!     integer(ik), intent(in)             :: nrec        ! Maximum recursion order
+!     real(rk), intent(out)               :: vb(0:p2(1),0:p2(2),0:p2(3),0:p2(4),0:nrec)
+!     real(rk), intent(in)                :: w_cut       ! Absolute cutoff for the integrals
+!     logical, intent(out)                :: zero        ! True if all integrals are smaller than w_cut
+!     !
+      real(kind(vb)) :: zeta, eta, rho, p(3), q(3), t, sab, scd        ! See Ahlrichs eqs. 3-6
+      real(kind(vb)) :: s                  ! Integral being evaluated
+      integer(ik)    :: i,   j,   k,   l   ! Integral indices
+      integer(ik)    :: id1, jd1, kd1, ld1 ! "parent" indices - drop one power for the cordinate ic
+      integer(ik)    :: id2, jd2, kd2, ld2 ! "parent" indices - drop two powers for the coordinate ic
+      integer(ik)    :: il,  jl,  kl,  ll  ! Sum of all coordinate powers for given function
+      integer(ik)    :: ic                 ! Coordinate to recurse along
+      integer(ik)    :: m                  ! Recursion order
+      real(kind(vb)) :: grow_factor        ! Estimate of the maximum amplification factor in integral recursion
+      real(kind(vb)) :: gf_tmp
+      !
+      ! There is a lot of overlap between formulae below and os_common_primitives()
+      ! 
+      zeta = zet(1) + zet(2)                                        ! Ahlrichs eq. 3
+      eta  = zet(3) + zet(4)                                        ! ... ditto
+      rho  = zeta * eta / (zeta + eta)                              ! ... ditto
+      p(:) = (zet(1)*xyz(:,1) + zet(2)*xyz(:,2))/zeta               ! Ahlrichs eq. 4
+      q(:) = (zet(3)*xyz(:,3) + zet(4)*xyz(:,4))/eta                ! ... ditto
+      t    = rho * sum((p-q)**2)                                    ! Ahlrichs eq. 5
+      sab  = exp(-(zet(1)*zet(2)/zeta)*sum((xyz(:,1)-xyz(:,2))**2)) ! Ahlrichs eq. 6
+      scd  = exp(-(zet(3)*zet(4)/eta )*sum((xyz(:,3)-xyz(:,4))**2)) ! ... ditto
+      !
+      ! write (out,"(' zeta = ',f25.15,' eta = ',f25.15,' rho = ',f25.15)") zeta, eta, rho
+      ! write (out,"(' p = ',3f25.15)") p
+      ! write (out,"(' q = ',3f25.15)") q
+      ! write (out,"(' xyz(:,1) = ',3f25.15)") xyz(:,1)
+      ! write (out,"(' xyz(:,2) = ',3f25.15)") xyz(:,2)
+      ! write (out,"(' xyz(:,3) = ',3f25.15)") xyz(:,3)
+      ! write (out,"(' xyz(:,4) = ',3f25.15)") xyz(:,4)
+      ! write (out,"(' t = ',f25.15,' sab = ',f25.15,' scd = ',f25.15)") t, sab, scd
+      !
+      !  Prepare basic integrals for recursion; this takes care of the S-type
+      !  integrals.
+      !
+      call os_basic_integral(what,rho,t,nrec,vb(0,0,0,0,0:nrec))
+      vb(0,0,0,0,0:nrec) = vb(0,0,0,0,0:nrec) * sab * scd * (real(pi_xrk,kind(zeta))/(zeta+eta))**real(1.5_xrk,kind(zeta))
+      !
+      !  Ready to apply the cut-offs. We'll try to be extremely conservative.
+      !
+      grow_factor = 1
+      ! (P-A) and (P-Q) prefactors in the recursion
+      m      = sum(ang_nxyz(p2,:))
+      gf_tmp = maxval(abs(p-q))
+      do i=1,4
+        gf_tmp = max(gf_tmp,maxval(abs(xyz(:,1) - p)))
+      end do
+      grow_factor = max(grow_factor,gf_tmp**m)
+      grow_factor = max(grow_factor,max(rho,real(0.5_xrk,kind(grow_factor))*MathFactorial(m,zeta))/zeta)
+      !
+      ! write (out,*) '       w_cut = ', w_cut
+      ! write (out,*) ' grow_factor = ', grow_factor
+      ! write (out,*) '  max. basic = ', maxval(abs(vb(0,0,0,0,0:nrec)))
+      if (maxval(abs(vb(0,0,0,0,0:nrec)))*grow_factor<=w_cut) then
+        ! write (out,*) ' batch is zero'
+        zero = .true.
+        return
+      end if
+      !
+      !  This integral is not obviously negligible, and will have to be evaluated.
+      !
+      zero = .false.
+      !
+      ! write (out,"(' basic integrals: '/(4f25.15))") vb(0,0,0,0,0:nrec)
+      !
+      !  Stage 1: keep the last three indices at zero; increment the first index
+      !           Ahlrichs' equation 32. All other indices are fixed at 1 (S functions)
+      !
+      boot_i: do i=1,p2(1)
+        call get_parent(i,ic,id1)
+        il = sum(ang_nxyz(i,:))
+        boot_i_order: do m=0,nrec-il
+            s = (p(ic)-xyz(ic,1)) * vb(id1,0,0,0,m) 
+            s = s - (rho/zeta) * (p(ic)-q(ic)) * vb(id1,0,0,0,m+1)
+            id2 = drop_xyz(id1,ic)
+            if (id2>=0) then
+              s = s + (ang_nxyz(id1,ic)/(2*zeta)) * (vb(id2,0,0,0,m) - (rho/zeta) * vb(id2,0,0,0,m+1))
+            end if
+            vb(i,0,0,0,m) = s
+        end do boot_i_order
+      end do boot_i
+      !
+      !  Stage 2: keep the second and the fourth indices to zero; increment the third index
+      !           This is Ahlrichs' equation 33.
+      !
+      boot_k: do k=1,p2(3)
+        call get_parent(k,ic,kd1)
+        kl  = sum(ang_nxyz(k,:))
+        kd2 = drop_xyz(kd1,ic)
+        boot_k_i: do i=0,p2(1)
+          id1 = drop_xyz(i,ic)
+          il  = sum(ang_nxyz(i,:))
+          boot_k_order: do m=0,nrec-(il+kl)
+            s = (q(ic)-xyz(ic,3)) * vb(i,0,kd1,0,m)
+            s = s + (rho/eta) * (p(ic)-q(ic)) * vb(i,0,kd1,0,m+1)
+            if (kd2>=0) then
+              s = s + (ang_nxyz(kd1,ic)/(2*eta)) * (vb(i,0,kd2,0,m) - (rho/eta) * vb(i,0,kd2,0,m+1))
+            end if
+            if (id1>=0) then
+              s = s + (ang_nxyz(i,ic)/(2*(zeta+eta))) * vb(id1,0,kd1,0,m+1)
+            end if
+            vb(i,0,k,0,m) = s
+          end do boot_k_order
+        end do boot_k_i
+      end do boot_k
+      !
+      !  Stage 3: keep the fourth index at zero; increment the second index. This is a
+      !           special case of Ahlrichs' equation 31. Note that eq. 31 as printed
+      !           is missing a closing square bracket after the second "b-1" term.
+      !
+      boot_j: do j=1,p2(2)
+        call get_parent(j,ic,jd1)
+        jl  = sum(ang_nxyz(j,:))
+        jd2 = drop_xyz(jd1,ic)
+        boot_j_k: do k=0,p2(3)
+          kd1 = drop_xyz(k,ic)
+          kl  = sum(ang_nxyz(k,:))
+          boot_j_i: do i=0,p2(1)
+            id1 = drop_xyz(i,ic)
+            il  = sum(ang_nxyz(i,:))
+            boot_j_order: do m=0,nrec-(jl+kl+il)
+              s = (p(ic)-xyz(ic,2)) * vb(i,jd1,k,0,m)
+              s = s - (rho/zeta) * (p(ic)-q(ic)) * vb(i,jd1,k,0,m+1)
+              if (jd2>=0) then
+                s = s + (ang_nxyz(jd1,ic)/(2*zeta)) * (vb(i,jd2,k,0,m) - (rho/zeta) * vb(i,jd2,k,0,m+1))
+              end if
+              if (id1>=0) then
+                s = s + (ang_nxyz(i,ic)/(2*zeta)) * (vb(id1,jd1,k,0,m) - (rho/zeta) * vb(id1,jd1,k,0,m+1))
+              end if
+              if (kd1>=0) then
+                s = s + (ang_nxyz(k,ic)/(2*(zeta+eta))) * vb(i,jd1,kd1,0,m+1)
+              end if
+              vb(i,j,k,0,m) = s
+            end do boot_j_order
+          end do boot_j_i
+        end do boot_j_k
+      end do boot_j
+      !
+      !  Stage 4: Increment the fourth index. This is the general-case eq. 31
+      !
+      boot_l: do l=1,p2(4)
+        call get_parent(l,ic,ld1)
+        ll  = sum(ang_nxyz(l,:))
+        ld2 = drop_xyz(ld1,ic)
+        boot_l_k: do k=0,p2(3)
+          kd1 = drop_xyz(k,ic)
+          kl  = sum(ang_nxyz(k,:))
+          boot_l_j: do j=0,p2(2)
+            jd1 = drop_xyz(j,ic)
+            jl  = sum(ang_nxyz(j,:))
+            boot_l_i: do i=0,p2(1)
+              id1 = drop_xyz(i,ic)
+              il  = sum(ang_nxyz(i,:))
+              boot_l_order: do m=0,nrec-(il+jl+kl+ll)
+                s = (q(ic)-xyz(ic,4)) * vb(i,j,k,ld1,m)
+                s = s - (rho/eta) * (q(ic)-p(ic)) * vb(i,j,k,ld1,m+1)
+                if (ld2>=0) then
+                  s = s + (ang_nxyz(ld1,ic)/(2*eta)) * (vb(i,j,k,ld2,m) - (rho/eta) * vb(i,j,k,ld2,m+1))
+                end if
+                if (kd1>=0) then
+                  s = s + (ang_nxyz(k,ic)/(2*eta)) * (vb(i,j,kd1,ld1,m) - (rho/eta) * vb(i,j,kd1,ld1,m+1))
+                end if
+                if (id1>=0) then
+                  s = s + (ang_nxyz(i,ic)/(2*(eta+zeta))) * vb(id1,j,k,ld1,m+1)
+                end if
+                if (jd1>=0) then
+                  s = s + (ang_nxyz(j,ic)/(2*(eta+zeta))) * vb(i,jd1,k,ld1,m+1)
+                end if
+                vb(i,j,k,l,m) = s
+              end do boot_l_order
+            end do boot_l_i
+          end do boot_l_j
+        end do boot_l_k
+      end do boot_l
+      contains
+      !
+      !  Determine the index to recurse along and the parent integral
+      !  This routine can be trivially made more efficient, but it probably does not matter (much)
+      !
+      subroutine get_parent(func,ic,id)
+        integer(ik), intent(in)  :: func  ! Target index
+        integer(ik), intent(out) :: ic    ! Coordinate to recurse along: 1, 2, or 3
+        integer(ik), intent(out) :: id    ! Parent integral
+        !
+        ic = 1 ; id = drop_xyz(func,ic) ; if (id>=0) return
+        ic = 2 ; id = drop_xyz(func,ic) ; if (id>=0) return
+        ic = 3 ; id = drop_xyz(func,ic) ; if (id>=0) return
+        stop 'import_gamess%os_2e_primitives - get_parent can''t get a parent!'
+      end subroutine get_parent
+!   end subroutine os_2e_primitives_real

--- a/import_gamess_os_basic_integral_common.f90
+++ b/import_gamess_os_basic_integral_common.f90
@@ -82,12 +82,12 @@
         !
         !  The next two interactions - 'A/(R**2+A**2)' and 'R/(R**2+A**2)' are
         !  needed to calculate Coulomb potential at a complex position. I can't
-        !  find an analytical expression for these kernels, so the code gets a 
+        !  find an analytical expression for these kernels, so the code gets a
         !  little more complicated, and relies on expansion of the 1/(R**2+A**2)
         !  term in Gaussians. Using the 200-term expansion in os_integral_operators,
         !  A values between 0.01 and 100 Bohr, rho values between 0.001 and 100,
         !  and T values from 10^(-3) to 120 yield errors (the smallest of the absolute
-        !  and relative error) of better than 1e-7. This is not great, but OK for 
+        !  and relative error) of better than 1e-7. This is not great, but OK for
         !  our intended use.
         !
         case ('A/(R**2+A**2)')

--- a/import_gamess_os_basic_integral_common.f90
+++ b/import_gamess_os_basic_integral_common.f90
@@ -1,0 +1,133 @@
+!   recursive subroutine os_basic_integral_real(what,rho,t,n_max,gn)
+!     type(gam_operator_data), intent(in) :: what        ! Operator parameters
+!     real(ark), intent(in)               :: rho         ! Effective basis exponent
+!     real(ark), intent(in)               :: t           ! Argument of the basic integral
+!     integer(ik), intent(in)             :: n_max       ! Maximum order of basic integral needed
+!     real(rk), intent(out)               :: gn(0:n_max) ! Basic integrals
+!     !
+      integer(ik)             :: n, i
+      real(kind(t))           :: gx(0:n_max+2)     ! Extra room, in case recursion needs a higher-order term
+      type(gam_operator_data) :: wx                ! Operator parameters for recursion
+      real(kind(t))           :: rx                ! rho for recursion
+      real(kind(t))           :: tx                ! t for recursion
+      real(rk), pointer       :: gp(:,:)           ! Gaussian expansion of an operator, only available in
+                                                   ! standard precision
+      !
+      ! write (out,"('os_basic: ',a,' rho = ',g14.7,' t = ',g14.7,' n = ',i4)") trim(what%op_name), rho, t, n_max
+      ! write (out,"('os_basic: omega = ',g14.7,' a = ',g14.7)") what%omega, what%imag_rc
+      !
+      select case (what%op_name(4:))
+        case default
+          write (out,"('import_gamess%os_basic_integral: Operator ',a,' is not implemented.')") trim(what%op_name(4:))
+          stop 'import_gamess%os_basic_integral - unimplemented'
+        !
+        !  "Primitive" cases first.
+        !
+        case ('DELTA') ! Delta function - A37
+          gn(:) = exp(-t)
+        case ('ONE')   ! Unity: an elaborate way to compute 2c overlaps - A38
+          gn(0)  = (real(pi_xrk,kind=kind(rho))/rho)**real(1.5_xrk,kind=kind(rho))
+          gn(1:) = 0
+        case ('1/R')   ! Nuclear attraction - A39
+          call os_boys_table(n_max,t,gn)
+          gn = (2*real(pi_xrk,kind=kind(rho))/rho) * gn
+        case ('R')     ! Linear attraction - A44
+          !
+          !  Linear attraction operator requires Boys' function table up to order n_max+1
+          !
+          call os_boys_table(n_max+1,t,gx(0:n_max+1))
+          gn(0) = (t+1)*gx(0) - t*gx(1)
+          gn_r_sum: do n=1,n_max
+            gn(n) = -n*gx(n-1) + (t+n+1)*gx(n) - t*gx(n+1)
+          end do gn_r_sum
+          gn = (2*real(pi_xrk,kind=kind(rho))/rho**2) * gn
+        case ('R**2')  ! Harmonic attraction - A45
+          gn(0) = (t + real(1.5_xrk,kind=kind(t)))
+          if (n_max>=1) gn(1)  = -1
+          if (n_max>=2) gn(2:) =  0
+          gn = sqrt(real(pi_xrk,kind=kind(rho))**3/rho**5) * gn
+        case ('GAUSS') ! Gaussian - same as 'GAUSS ONE', but likely slightly faster
+          rx = real(what%omega,kind=kind(rho))/(rho+real(what%omega,kind=kind(rho)))
+          gn_gauss: do n=0,n_max
+            gn(n) = rx**n
+          end do gn_gauss
+          gn = gn * exp(-rx*t) * real(pi_xrk,kind=kind(rho))/ &
+               (rho+real(what%omega,kind=kind(rho)))**real(1.5_xrk,kind=kind(rho))
+        !
+        !  Recursive cases - reduction to simpler Gn(t)
+        !
+        case ('GAUSS ONE','GAUSS R')
+          !
+          !  g(r) = exp(-omega*r**2) * gx(r), for an arbitrary gx(r) - A41
+          !  There is no increase in the Gn order. Note that the full reduction
+          !  below is an overkill if Gx does not have t dependence. However, any
+          !  savings are likely trivial.
+          !
+          wx = what
+          wx%op_name(4:) = what%op_name(4+6:)
+          rx = rho + real(what%omega,kind=kind(rho))
+          tx = t * rho / rx
+          call os_basic_integral(wx,rx,tx,n_max,gx(0:n_max))
+          !
+          !  This is not the most elegant way to organize this loop, but it probably
+          !  does not matter ...
+          !
+          gn_gaussian_recursion: do n=0,n_max
+            gn(n) = 0
+            gn_gaussian_sum: do i=0,n
+              gn(n) = gn(n) + MathBinomial(n,i,rx) * (real(what%omega,kind=kind(rx))/rx)**(n-i) * (rho/rx)**i * gx(i)
+            end do gn_gaussian_sum
+          end do gn_gaussian_recursion
+          gn = gn * exp(-real(what%omega,kind=kind(t))*t/rx)
+        !
+        !  The next two interactions - 'A/(R**2+A**2)' and 'R/(R**2+A**2)' are
+        !  needed to calculate Coulomb potential at a complex position. I can't
+        !  find an analytical expression for these kernels, so the code gets a 
+        !  little more complicated, and relies on expansion of the 1/(R**2+A**2)
+        !  term in Gaussians. Using the 200-term expansion in os_integral_operators,
+        !  A values between 0.01 and 100 Bohr, rho values between 0.001 and 100,
+        !  and T values from 10^(-3) to 120 yield errors (the smallest of the absolute
+        !  and relative error) of better than 1e-7. This is not great, but OK for 
+        !  our intended use.
+        !
+        case ('A/(R**2+A**2)')
+          if (kind(t)/=rk) stop 'import_gamess%os_basic_integral - requested integral is not implemented in quad precision'
+          call warn_integral_accuracy
+          wx = what
+          wx%op_name = '3C GAUSS'
+          gp => operator_1_1pr2
+          gn = 0
+          gn_complex_integrate_a: do i=1,size(gp,dim=2)
+            wx%omega = gp(1,i)/what%imag_rc**2
+            call os_basic_integral(wx,rho,t,n_max,gx(0:n_max))
+            gn = gn + gx(0:n_max) * gp(2,i)/real(what%imag_rc,kind=kind(gp))
+          end do gn_complex_integrate_a
+        case ('R/(R**2+A**2)')
+          if (kind(t)/=rk) stop 'import_gamess%os_basic_integral - requested integral is not implemented in quad precision'
+          call warn_integral_accuracy
+          wx = what
+          wx%op_name = '3C GAUSS R'
+          gp => operator_1_1pr2
+          gn = 0
+          gn_complex_integrate_r: do i=1,size(gp,dim=2)
+            wx%omega = gp(1,i)/what%imag_rc**2
+            call os_basic_integral(wx,rho,t,n_max,gx(0:n_max))
+            gn = gn + gx(0:n_max) * gp(2,i)/real(what%imag_rc,kind=kind(gp))**2
+          end do gn_complex_integrate_r
+      end select
+      ! write (out,"('os_basic: gn =',10(1x,g14.7))") gn
+      contains
+      subroutine warn_integral_accuracy
+        integer(ik) :: this_thread
+        !
+        logical, save :: warned = .false.
+        this_thread = 0
+        !$ this_thread = omp_get_thread_num()
+        if (this_thread/=0 .or. warned) return
+        warned = .true.
+        write (out,"(/'WARNING: This program utilizes ',a,'-type integrals.')") trim(what%op_name)
+        write (out,"( 'WARNING: The numerical accuracy domain for these integrals is restricted.')")
+        write (out,"( 'WARNING: Please make sure you understand code in import_gamess%os_basic_integral')")
+        write (out,"( 'WARNING: before using these integrals for production calculations.'/)")
+      end subroutine warn_integral_accuracy
+!   end subroutine os_basic_integral_real

--- a/import_gamess_os_boys_table_common.f90
+++ b/import_gamess_os_boys_table_common.f90
@@ -1,0 +1,18 @@
+!   subroutine os_boys_table_real(n_max,t,fn)
+!     integer(ik), intent(in) :: n_max       ! Max. desired order of the Boys' function
+!     real(rk), intent(in)    :: t           ! Argument of the Boys' function
+!     real(rk), intent(out)   :: fn(0:n_max) ! Table for the function values
+!     !
+      real(kind(t))           :: expt
+      integer(ik)             :: n
+      !
+      !  Evaluation of the Boys' function in MathBoysF is accurate, but quite inefficient.
+      !  If timing becomes an issue, table-based power-series expansion (as in OS) is
+      !  probably the simplest option to improve the speed.
+      !
+      expt = exp(-t)
+      fn(n_max) = MathBoysF(n_max,t)
+      fn_boys_recursion: do n=n_max-1,0,-1
+        fn(n) = (2*t*fn(n+1)+expt)/(2*n+1)
+      end do fn_boys_recursion
+!   end subroutine os_boys_table_real

--- a/import_gamess_os_common_primitives_common.f90
+++ b/import_gamess_os_common_primitives_common.f90
@@ -2,7 +2,7 @@
 !     real(ark), intent(in)            :: r_l(:)  ! Centre of the left b.f.
 !     real(ark), intent(in)            :: z_l     ! Orbital exponent of the left b.f.
 !     real(ark), intent(in)            :: r_r(:)  ! ditto, for the right b.f.
-!     real(ark), intent(in)            :: z_r     ! 
+!     real(ark), intent(in)            :: z_r     !
 !     real(ark), intent(out), optional :: xi      ! Eq. 13 of Obara-Saika
 !     real(ark), intent(out), optional :: zeta    ! Eq. 14
 !     real(ark), intent(out), optional :: p(:)    ! Eq. 15

--- a/import_gamess_os_common_primitives_common.f90
+++ b/import_gamess_os_common_primitives_common.f90
@@ -1,0 +1,18 @@
+!   subroutine os_common_primitives_real(r_l,z_l,r_r,z_r,xi,zeta,p,s00,s00a)
+!     real(ark), intent(in)            :: r_l(:)  ! Centre of the left b.f.
+!     real(ark), intent(in)            :: z_l     ! Orbital exponent of the left b.f.
+!     real(ark), intent(in)            :: r_r(:)  ! ditto, for the right b.f.
+!     real(ark), intent(in)            :: z_r     ! 
+!     real(ark), intent(out), optional :: xi      ! Eq. 13 of Obara-Saika
+!     real(ark), intent(out), optional :: zeta    ! Eq. 14
+!     real(ark), intent(out), optional :: p(:)    ! Eq. 15
+!     real(ark), intent(out), optional :: s00     ! Eq. 22
+!     real(ark), intent(out), optional :: s00a    ! Ahlrichs' version of s00 - no prefactor
+!     !
+      if (present(xi)  ) xi   = z_l*z_r/(z_l+z_r)
+      if (present(zeta)) zeta = z_l + z_r
+      if (present(p)   ) p    = (z_l*r_l + z_r*r_r)/(z_l+z_r)
+      if (present(s00) ) s00  = (real(pi,kind=kind(z_l))/(z_l+z_r))**real(1.5_xrk,kind=kind(z_l)) &
+                                                       * exp(-(z_l*z_r/(z_l+z_r))*sum((r_l-r_r)**2))
+      if (present(s00a)) s00a =                          exp(-(z_l*z_r/(z_l+z_r))*sum((r_l-r_r)**2))
+!   end subroutine os_common_primitives_real

--- a/import_gamess_print_1e_integrals_common.f90
+++ b/import_gamess_print_1e_integrals_common.f90
@@ -1,0 +1,56 @@
+      type(gam_structure), pointer :: l, r
+      integer(ik)                  :: ir, ic, ic_p1, ic_pn
+      integer(ik), parameter       :: cpp = 10               ! Columns per page
+      logical                      :: usegfmt
+      character(len=20)            :: sym, head
+      character(len=20)            :: lab
+      !
+      call TimerStart('GAMESS print 1e')
+      l => gam_def ; r => gam_def
+      if (present(bra)) l => bra
+      if (present(ket)) r => ket
+      !
+      !  Symmetry check
+      !
+      sym = 'HERMITIAN'
+      if (present(symmetry)) sym = symmetry
+      if (size(v,dim=1)==size(v,dim=2)) then
+        write (out,"('Expected integral symmetry: ',a)") trim(sym)
+        select case (sym)
+          case default
+            write (out,"('Symmetry code ',a,' is not recognized')") trim(sym)
+            stop 'import_gamess%gamess_print_1e_integrals_real - bad argument'
+          case ('NONE')
+          case ('HERMITIAN')
+            write (out,"('    Maximum deviation from symmetry = ',g12.5)") maxval(abs(v-transpose(v)))
+            write (out,"('         Maximum deviation at index = ',2i6  )") maxloc(abs(v-transpose(v)))
+          case ('ANTI-HERMITIAN')
+            write (out,"('    Maximum deviation from symmetry = ',g12.5)") maxval(abs(v+transpose(v)))
+            write (out,"('         Maximum deviation at index = ',2i6  )") maxloc(abs(v+transpose(v)))
+        end select
+      end if
+            write (out,"('             Largest matrix element = ',g12.5)") maxval(v)
+            write (out,"(' Largest matrix element is at index = ',2i6)") maxloc(v)
+            write (out,"('            Smallest matrix element = ',g12.5)") minval(v)
+            write (out,"('Smallest matrix element is at index = ',2i6)") minloc(v)
+      !
+      head = 'BOTH'
+      if (present(heading)) head = heading
+      usegfmt = any(abs(v)>=1e5) .or. all(abs(v)<=1e-3)
+      print_pages: do ic_p1=1,r%nbasis,cpp
+        ic_pn = min(r%nbasis,ic_p1+cpp-1)
+        write (out,"(t17,10(1x,i12))") (ic,               ic=ic_p1,ic_pn)
+        if (head=='BOTH') write (out,"(t23,10(1x,a12))") (r%bas_labels(ic), ic=ic_p1,ic_pn)
+        print_rows: do ir=1,l%nbasis
+          lab = ' '
+          if (head/='NONE') lab = l%bas_labels(ir)
+          if (usegfmt) then
+            write (out,"(1x,i5,1x,a11,1x,10(1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+          else
+            write (out,"(1x,i5,1x,a11,1x,10(1x,f12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+          endif
+        end do print_rows
+        write (out,"()")
+      end do print_pages
+      !
+      call TimerStop('GAMESS print 1e')

--- a/import_gamess_print_1e_integrals_common.f90
+++ b/import_gamess_print_1e_integrals_common.f90
@@ -39,15 +39,15 @@
       usegfmt = any(abs(v)>=1e5) .or. all(abs(v)<=1e-3)
       print_pages: do ic_p1=1,r%nbasis,cpp
         ic_pn = min(r%nbasis,ic_p1+cpp-1)
-        write (out,"(t17,10(1x,i12))") (ic,               ic=ic_p1,ic_pn)
-        if (head=='BOTH') write (out,"(t23,10(1x,a12))") (r%bas_labels(ic), ic=ic_p1,ic_pn)
+        write (out,"(t19,10(1x,i12))") (ic,               ic=ic_p1,ic_pn)
+        if (head=='BOTH') write (out,"(t25,10(a13))") (r%bas_labels(ic), ic=ic_p1,ic_pn)
         print_rows: do ir=1,l%nbasis
           lab = ' '
           if (head/='NONE') lab = l%bas_labels(ir)
           if (usegfmt) then
-            write (out,"(1x,i5,1x,a11,1x,10(1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+            write (out,"(1x,i5,1x,a13,1x,10(1x,g12.5))") ir, lab, v(ir,ic_p1:ic_pn)
           else
-            write (out,"(1x,i5,1x,a11,1x,10(1x,f12.5))") ir, lab, v(ir,ic_p1:ic_pn)
+            write (out,"(1x,i5,1x,a13,1x,10(1x,f12.5))") ir, lab, v(ir,ic_p1:ic_pn)
           endif
         end do print_rows
         write (out,"()")

--- a/lapack.f90
+++ b/lapack.f90
@@ -60,7 +60,7 @@ module lapack
   interface lapack_svd
      module procedure lapack_dgesvd
      module procedure lapack_zgesvd
-  end interface lapack_svd  
+  end interface lapack_svd
 
   interface lapack_gesv
      module procedure lapack_zgesv
@@ -92,7 +92,7 @@ module lapack
     real(srk)    :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
     integer      :: rank, info           ! Must be of default integer kind
     integer      :: na1, na2, nb1, nb2   ! Must be of default integer kind
-    
+
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
     call cgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
@@ -114,7 +114,7 @@ module lapack
     real(drk)         :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
     integer           :: rank, info         ! Must be of default integer kind
     integer           :: na1, na2, nb1, nb2 ! Must be of default integer kind
-    
+
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
     call zgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
@@ -129,7 +129,7 @@ module lapack
 !*qd subroutine lapack_quad_zgelss(a,b)
 !*qd  complex(qrk), intent(inout) :: a(:,:)
 !*qd  complex(qrk), intent(inout) :: b(:,:)
-!*qd  
+!*qd
 !*qd  external quad_zgelss
 !*qd  real(qrk)    :: s    (   min(size(a,dim=1),size(a,dim=2)))
 !*qd  complex(qrk) :: work (50*max(size(a,dim=1),size(a,dim=2)))
@@ -137,13 +137,13 @@ module lapack
 !*qd  real(qrk)    :: eps
 !*qd  integer      :: rank, info          ! Must be of default integer kind
 !*qd  integer      :: na1, na2, nb1, nb2  ! Must be of default integer kind
-!*qd 
+!*qd
 !*qd  na1 = size(a,dim=1) ; na2 = size(a,dim=2)
 !*qd  nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
 !*qd  eps = 100*spacing(eps)
 !*qd  call quad_zgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
 !*qd                   s, eps, rank, work, size(work), rwork, info)
-!*qd  
+!*qd
 !*qd  if (info/=0) then
 !*qd    write (out,"(' quad_cgelss returned ',i8)") info
 !*qd    stop 'lapack_quad_cgelss - quad_cgelss failed'
@@ -159,7 +159,7 @@ module lapack
     real(srk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
     integer   :: rank, info          ! Must be of default integer kind
     integer   :: na1, na2, nb1, nb2  ! Must be of default integer kind
-    
+
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
     call sgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
@@ -180,7 +180,7 @@ module lapack
     real(drk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
     integer   :: rank, info         ! Must be of default integer kind
     integer   :: na1, na2, nb1, nb2 ! Must be of default integer kind
-    
+
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
     call dgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
@@ -195,13 +195,13 @@ module lapack
 !*qd subroutine lapack_quad_dgelss(a,b)
 !*qd  real(qrk), intent(inout) :: a(:,:)
 !*qd  real(qrk), intent(inout) :: b(:,:)
-  
+
 !*qd  external quad_dgelss
 !*qd  real(qrk) :: s    (   min(size(a,dim=1),size(a,dim=2)))
 !*qd  real(qrk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
 !*qd  integer   :: rank, info         ! Must be of default integer kind
 !*qd  integer   :: na1, na2, nb1, nb2 ! Must be of default integer kind
-!*qd  
+!*qd
 !*qd  na1 = size(a,dim=1) ; na2 = size(a,dim=2)
 !*qd  nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
 !*qd  call quad_dgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
@@ -254,7 +254,7 @@ module lapack
   end subroutine lapack_dsysv
 
   subroutine lapack_sstev(d,e,z)
-    real(srk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
+    real(srk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix
                                        ! Out: Eigenvalues, ascending order
     real(srk), intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
                                        ! Out: Destroyed
@@ -263,7 +263,7 @@ module lapack
     real(srk) :: work(max(1,2*size(d)-2))
     integer   :: info      ! Must be of default integer kind
     integer   :: nz1, nz2  ! Must be of default integer kind
-    
+
     nz1 = size(z,dim=1) ; nz2 = size(z,dim=2)
     call sstev('V',size(d),d,e,z(1:nz1,1:nz2),nz1,work,info)
 
@@ -274,7 +274,7 @@ module lapack
   end subroutine lapack_sstev
 
   subroutine lapack_dstev(d,e,z)
-    real(drk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
+    real(drk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix
                                               ! Out: Eigenvalues, ascending order
     real(drk), intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
                                               ! Out: Destroyed
@@ -283,7 +283,7 @@ module lapack
     real(drk) :: work(max(1,2*size(d)-2))
     integer   :: info      ! Must be of default integer kind
     integer   :: nz1, nz2  ! Must be of default integer kind
-    
+
     nz1 = size(z,dim=1) ; nz2 = size(z,dim=2)
     call dstev('V',size(d),d,e,z(1:nz1,1:nz2),nz1,work,info)
 
@@ -304,7 +304,7 @@ module lapack
     complex(srk) :: vr(size(h,dim=2),size(h,dim=2))
     integer      :: info      ! Must be of default integer kind
     integer      :: nh1, nh2  ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call cgeev('N','V',nh2,h(1:nh1,1:nh2),nh1,e(:),vl,1,vr,nh2,work,size(work),rwork,info)
     if (info/=0) then
@@ -325,7 +325,7 @@ module lapack
     complex(kind=drk) :: vr(size(h,dim=2),size(h,dim=2))
     integer           :: info     ! Must be of default integer kind
     integer           :: nh1, nh2 ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call zgeev('N','V',nh2,h(1:nh1,1:nh2),nh1,e(:),vl,1,vr,nh2,work,size(work),rwork,info)
     if (info/=0) then
@@ -346,7 +346,7 @@ module lapack
     complex(kind=drk) :: vl(size(h,dim=2),size(h,dim=2))
     integer           :: info     ! Must be of default integer kind
     integer           :: nh1, nh2 ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     if (nh1<nh2) stop 'lapack_zgeev2 - oops'
     call zgeev('V','V',nh2,h(1:nh1,1:nh2,1),nh1,e(:),vl,nh2,h(1:nh1,1:nh2,2),nh1,work,size(work),rwork,info)
@@ -362,13 +362,13 @@ module lapack
 !*qd                                           ! Out: h(:,:,1) = Left eigenvectors
 !*qd                                           !      h(:,:,2) = Right eigenvectors
 !*qd   complex(qrk), intent(out)   :: e(:)     ! Out: Eigenvalues
-   
+
 !*qd   complex(qrk) :: work(50*size(h,dim=2))
 !*qd   real(qrk)    :: rwork(3*size(h,dim=2))
 !*qd   complex(qrk) :: vl(size(h,dim=2),size(h,dim=2))
 !*qd   integer      :: info      ! Must be of default integer kind
 !*qd   integer      :: nh1, nh2  ! Must be of default integer kind
-!*qd   
+!*qd
 !*qd   nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
 !*qd   if (nh1<nh2) stop 'lapack%lapack_quad_zgeev2 - oops'
 !*qd   call quad_zgeev('V','V',nh2,h(1:nh1,1:nh2,1),nh1,e(:),vl,nh2,h(1:nh1,1:nh2,2),nh1,work,size(work),rwork,info)
@@ -388,7 +388,7 @@ module lapack
     real(srk)    :: rwork(3*size(h,dim=1))
     integer      :: info                   ! Must be of default integer kind
     integer      :: nh1, nh2               ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call cheev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),rwork,info)
     if (info/=0) then
@@ -406,7 +406,7 @@ module lapack
     real(drk)    :: rwork(3*size(h,dim=1))
     integer      :: info            ! Must be of default integer kind
     integer      :: nh1, nh2        ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call zheev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),rwork,info)
     if (info/=0) then
@@ -423,7 +423,7 @@ module lapack
     real(drk) :: work(50*size(h,dim=1))
     integer   :: info      ! Must be of default integer kind
     integer   :: nh1, nh2  ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call dsyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
     if (info/=0) then
@@ -436,11 +436,11 @@ module lapack
 !*qd   real(qrk), intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
 !*qd                                       ! Out: Eigenvectors
 !*qd   real(qrk), intent(out)   :: e(:)    ! Out: Eigenvalues
-   
+
 !*qd   real(qrk) :: work(50*size(h,dim=1))
 !*qd   integer   :: info       ! Must be of default integer kind
 !*qd   integer   :: nh1, nh2   ! Must be of default integer kind
-!*qd   
+!*qd
 !*qd   nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
 !*qd   call quad_dsyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
 !*qd   if (info/=0) then
@@ -457,7 +457,7 @@ module lapack
     real(srk)        :: work(50*size(h,dim=1))
     integer          :: info       ! Must be of default integer kind
     integer          :: nh1, nh2   ! Must be of default integer kind
-    
+
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call ssyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
     if (info/=0) then
@@ -480,9 +480,9 @@ module lapack
     real(drk), allocatable :: work(:)
     integer                :: info, lwork                    ! Must be of default integer kind
     integer                :: m, n, lda, ldu, ldvth, nsing   ! Must be of default integer kind
-   
-    m     = size(a,dim=1) 
-    n     = size(a,dim=2) 
+
+    m     = size(a,dim=1)
+    n     = size(a,dim=2)
     lda   = m
     nsing = min(m,n)
     ldu   = size(u,dim=1)
@@ -533,9 +533,9 @@ module lapack
     real(drk)    :: rwork(5*size(a,dim=1))
     integer      :: info, lwork           ! Must be of default integer kind
     integer      :: m, n, lda, ldu, ldvth ! Must be of default integer kind
-   
+
     m     = size(a,dim=1) ; lda = m
-    n     = size(a,dim=2) 
+    n     = size(a,dim=2)
     ldu   = size(u,dim=1)
     ldvth = size(vth,dim=1)
     lwork = size(work)
@@ -611,9 +611,9 @@ module lapack
     evec  = amat
     call lapack_syev(evec(:,:),eval(:))
     eps = 100.0*spacing(maxval(eval))
-    where (abs(eval)>eps) 
+    where (abs(eval)>eps)
       eval = 1.0 / eval**power
-    elsewhere  
+    elsewhere
       eval = 0.0
     end where
     evec = evec * spread(eval,dim=1,ncopies=size(evec,dim=1))
@@ -638,9 +638,9 @@ module lapack
     evec  = amat
     call lapack_heev(evec(:,:),eval(:))
     eps = 100.0*spacing(maxval(eval))
-    where (abs(eval)>eps) 
+    where (abs(eval)>eps)
       eval = 1.0 / eval**power
-    elsewhere  
+    elsewhere
       eval = 0.0
     end where
     evec = evec * spread(eval,dim=1,ncopies=size(evec,dim=1))
@@ -665,9 +665,9 @@ module lapack
     evec = amat
     call lapack_syev(evec(:,:),eval(:))
     eps = 100.0d0*spacing(maxval(eval))
-    where (abs(eval)>eps) 
+    where (abs(eval)>eps)
       eval = 1.0d0 / eval**power
-    elsewhere  
+    elsewhere
       eval = 0.0d0
     end where
     evec = evec * spread(eval,dim=1,ncopies=size(evec,dim=1))
@@ -692,9 +692,9 @@ module lapack
     evec  = amat
     call lapack_heev(evec(:,:),eval(:))
     eps = 100.0d0*spacing(maxval(eval))
-    where (abs(eval)>eps) 
+    where (abs(eval)>eps)
       eval = 1.0d0 / eval**power
-    elsewhere  
+    elsewhere
       eval = 0.0
     end where
     evec = evec * spread(eval,dim=1,ncopies=size(evec,dim=1))

--- a/lapack.f90
+++ b/lapack.f90
@@ -6,73 +6,92 @@ module lapack
   implicit none
 
   interface lapack_gelss
-    module procedure lapack_cgelss
-    module procedure lapack_zgelss
-    module procedure lapack_sgelss
-    module procedure lapack_dgelss
-  end interface ! lapack_gelss
+     module procedure lapack_cgelss
+     module procedure lapack_zgelss
+     module procedure lapack_sgelss
+     module procedure lapack_dgelss
+!*qd module procedure lapack_quad_dgelss
+!*qd module procedure lapack_quad_zgelss
+  end interface lapack_gelss
 
   interface lapack_posv
     module procedure lapack_dposv
-  end interface ! lapack_posv
+  end interface lapack_posv
 
   interface lapack_sysv
     module procedure lapack_dsysv
-  end interface ! lapack_dsysv
+  end interface lapack_sysv
 
   interface lapack_stev
-    module procedure lapack_sstev
-    module procedure lapack_dstev
-  end interface ! lapack_stev
+     module procedure lapack_sstev
+     module procedure lapack_dstev
+  end interface lapack_stev
 
   interface lapack_sterf
-    module procedure lapack_dsterf
-    module procedure lapack_ssterf
-  end interface ! lapack_sterf
+     module procedure lapack_dsterf
+     module procedure lapack_ssterf
+  end interface lapack_sterf
 
   interface lapack_geev
-    module procedure lapack_cgeev
-    module procedure lapack_zgeev
-  end interface ! lapack_geev
+     module procedure lapack_cgeev
+     module procedure lapack_zgeev
+     module procedure lapack_zgeev2
+!*qd module procedure lapack_quad_zgeev2
+  end interface lapack_geev
 
   interface lapack_heev
-    module procedure lapack_cheev
-    module procedure lapack_zheev
-  end interface ! lapack_heev
+     module procedure lapack_cheev
+     module procedure lapack_zheev
+  end interface lapack_heev
 
   interface lapack_syev
-    module procedure lapack_dsyev
-    module procedure lapack_ssyev
-  end interface ! lapack_syev
+     module procedure lapack_dsyev
+     module procedure lapack_ssyev
+!*qd module procedure lapack_quad_dsyev
+  end interface lapack_syev
 
   interface lapack_ginverse
-    module procedure lapack_ginverse_real
-    module procedure lapack_ginverse_double
-    module procedure lapack_ginverse_complex
-    module procedure lapack_ginverse_doublecomplex
-  end interface ! lapack_ginverse
+     module procedure lapack_ginverse_real
+     module procedure lapack_ginverse_double
+     module procedure lapack_ginverse_complex
+     module procedure lapack_ginverse_doublecomplex
+  end interface lapack_ginverse
 
   interface lapack_svd
-    module procedure lapack_dgesvd
-    module procedure lapack_zgesvd
-  end interface ! lapack_svd  
+     module procedure lapack_dgesvd
+     module procedure lapack_zgesvd
+  end interface lapack_svd  
+
+  interface lapack_gesv
+     module procedure lapack_zgesv
+!*qd module procedure lapack_quad_zgesv
+  end interface lapack_gesv
 
   interface linpack_determinant
-    module procedure linpack_determinant_double
-  end interface ! linpack_determinant
+     module procedure linpack_determinant_double
+  end interface linpack_determinant
+
+  interface linpack_determinant_trash_input
+     module procedure linpack_determinant_double_trash_input
+  end interface linpack_determinant_trash_input
+
+  interface lapack_determinant
+     module procedure lapack_determinant_double
+!*qd module procedure lapack_determinant_quad
+  end interface lapack_determinant
 
   contains
 
   subroutine lapack_cgelss(a,b)
-    complex, intent(inout) :: a(:,:)
-    complex, intent(inout) :: b(:,:)
+    complex(srk), intent(inout) :: a(:,:)
+    complex(srk), intent(inout) :: b(:,:)
 
     external cgelss
-    real                   :: s    (   min(size(a,dim=1),size(a,dim=2)))
-    complex                :: work (50*max(size(a,dim=1),size(a,dim=2)))
-    real                   :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
-    integer                :: rank, info
-    integer                :: na1, na2, nb1, nb2
+    real(srk)    :: s    (   min(size(a,dim=1),size(a,dim=2)))
+    complex(srk) :: work (50*max(size(a,dim=1),size(a,dim=2)))
+    real(srk)    :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
+    integer      :: rank, info           ! Must be of default integer kind
+    integer      :: na1, na2, nb1, nb2   ! Must be of default integer kind
     
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -90,11 +109,11 @@ module lapack
     complex(kind=drk), intent(inout) :: b(:,:)
 
     external zgelss
-    double precision       :: s    (   min(size(a,dim=1),size(a,dim=2)))
-    complex(kind=drk)         :: work (50*max(size(a,dim=1),size(a,dim=2)))
-    double precision       :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
-    integer                :: rank, info
-    integer                :: na1, na2, nb1, nb2
+    real(drk)         :: s    (   min(size(a,dim=1),size(a,dim=2)))
+    complex(kind=drk) :: work (50*max(size(a,dim=1),size(a,dim=2)))
+    real(drk)         :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
+    integer           :: rank, info         ! Must be of default integer kind
+    integer           :: na1, na2, nb1, nb2 ! Must be of default integer kind
     
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -107,15 +126,39 @@ module lapack
     end if
   end subroutine lapack_zgelss
 
+!*qd subroutine lapack_quad_zgelss(a,b)
+!*qd  complex(qrk), intent(inout) :: a(:,:)
+!*qd  complex(qrk), intent(inout) :: b(:,:)
+!*qd  
+!*qd  external quad_zgelss
+!*qd  real(qrk)    :: s    (   min(size(a,dim=1),size(a,dim=2)))
+!*qd  complex(qrk) :: work (50*max(size(a,dim=1),size(a,dim=2)))
+!*qd  real(qrk)    :: rwork( 5*min(size(a,dim=1),size(a,dim=2)))
+!*qd  real(qrk)    :: eps
+!*qd  integer      :: rank, info          ! Must be of default integer kind
+!*qd  integer      :: na1, na2, nb1, nb2  ! Must be of default integer kind
+!*qd 
+!*qd  na1 = size(a,dim=1) ; na2 = size(a,dim=2)
+!*qd  nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
+!*qd  eps = 100*spacing(eps)
+!*qd  call quad_zgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
+!*qd                   s, eps, rank, work, size(work), rwork, info)
+!*qd  
+!*qd  if (info/=0) then
+!*qd    write (out,"(' quad_cgelss returned ',i8)") info
+!*qd    stop 'lapack_quad_cgelss - quad_cgelss failed'
+!*qd  end if
+!*qd end subroutine lapack_quad_zgelss
+
   subroutine lapack_sgelss(a,b)
-    real, intent(inout) :: a(:,:)
-    real, intent(inout) :: b(:,:)
+    real(srk), intent(inout) :: a(:,:)
+    real(srk), intent(inout) :: b(:,:)
 
     external sgelss
-    real                :: s    (   min(size(a,dim=1),size(a,dim=2)))
-    real                :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
-    integer             :: rank, info
-    integer             :: na1, na2, nb1, nb2
+    real(srk) :: s    (   min(size(a,dim=1),size(a,dim=2)))
+    real(srk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
+    integer   :: rank, info          ! Must be of default integer kind
+    integer   :: na1, na2, nb1, nb2  ! Must be of default integer kind
     
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -129,14 +172,14 @@ module lapack
   end subroutine lapack_sgelss
 
   subroutine lapack_dgelss(a,b)
-    double precision, intent(inout) :: a(:,:)
-    double precision, intent(inout) :: b(:,:)
+    real(drk), intent(inout) :: a(:,:)
+    real(drk), intent(inout) :: b(:,:)
 
     external dgelss
-    double precision    :: s    (   min(size(a,dim=1),size(a,dim=2)))
-    double precision    :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
-    integer             :: rank, info
-    integer             :: na1, na2, nb1, nb2
+    real(drk) :: s    (   min(size(a,dim=1),size(a,dim=2)))
+    real(drk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
+    integer   :: rank, info         ! Must be of default integer kind
+    integer   :: na1, na2, nb1, nb2 ! Must be of default integer kind
     
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -149,14 +192,35 @@ module lapack
     end if
   end subroutine lapack_dgelss
 
+!*qd subroutine lapack_quad_dgelss(a,b)
+!*qd  real(qrk), intent(inout) :: a(:,:)
+!*qd  real(qrk), intent(inout) :: b(:,:)
+  
+!*qd  external quad_dgelss
+!*qd  real(qrk) :: s    (   min(size(a,dim=1),size(a,dim=2)))
+!*qd  real(qrk) :: work (50*max(size(a,dim=1),size(a,dim=2),size(b,dim=2)))
+!*qd  integer   :: rank, info         ! Must be of default integer kind
+!*qd  integer   :: na1, na2, nb1, nb2 ! Must be of default integer kind
+!*qd  
+!*qd  na1 = size(a,dim=1) ; na2 = size(a,dim=2)
+!*qd  nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
+!*qd  call quad_dgelss(na1,na2,nb2,a(1:na1,1:na2),na1,b(1:nb1,1:nb2),nb1, &
+!*qd                   s, 100._qrk*spacing(1.0_qrk), rank, work, size(work), info)
+
+!*qd  if (info/=0) then
+!*qd    write (out,"(' quad_dgelss returned ',i8)") info
+!*qd    stop 'lapack_quad_dgelss - quad_dgelss failed'
+!*qd  end if
+!*qd end subroutine lapack_quad_dgelss
+
   subroutine lapack_dposv(a,b)
-    double precision, intent(inout) :: a(:,:) ! In:  Left hand side matrix A in AX = B
+    real(drk), intent(inout) :: a(:,:) ! In:  Left hand side matrix A in AX = B
                                               ! Out: Cholesky factor L
-    double precision, intent(inout) :: b(:,:) ! In:  Right hand side matrix B in AX = B
+    real(drk), intent(inout) :: b(:,:) ! In:  Right hand side matrix B in AX = B
                                               ! Out: Solution matrix X
     external dposv
-    integer                         :: info
-    integer                         :: na1, na2, nb1, nb2
+    integer                  :: info
+    integer                  :: na1, na2, nb1, nb2
 
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -169,14 +233,14 @@ module lapack
   end subroutine lapack_dposv
 
   subroutine lapack_dsysv(a,b)
-    double precision, intent(inout) :: a(:,:) ! In:  Left hand side matrix A in AX = B
+    real(drk), intent(inout) :: a(:,:) ! In:  Left hand side matrix A in AX = B
                                               ! Out: Cholesky factor L
-    double precision, intent(inout) :: b(:,:) ! In:  Right hand side matrix B in AX = B
+    real(drk), intent(inout) :: b(:,:) ! In:  Right hand side matrix B in AX = B
                                               ! Out: Solution matrix X
     external dsysv
-    integer                         :: lwork, info, ipiv(max(1,2*size(a,dim=2)))
-    integer                         :: na1, na2, nb1, nb2
-    double precision                :: work(max(1,2*size(a,dim=2)))
+    integer                  :: lwork, info, ipiv(max(1,2*size(a,dim=2)))
+    integer                  :: na1, na2, nb1, nb2
+    real(drk)                :: work(max(1,2*size(a,dim=2)))
 
     na1 = size(a,dim=1) ; na2 = size(a,dim=2)
     nb1 = size(b,dim=1) ; nb2 = size(b,dim=2)
@@ -190,15 +254,15 @@ module lapack
   end subroutine lapack_dsysv
 
   subroutine lapack_sstev(d,e,z)
-    real, intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
-                                  ! Out: Eigenvalues, ascending order
-    real, intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
-                                  ! Out: Destroyed
-    real, intent(out)   :: z(:,:) ! Out: Eigenvectors
+    real(srk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
+                                       ! Out: Eigenvalues, ascending order
+    real(srk), intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
+                                       ! Out: Destroyed
+    real(srk), intent(out)   :: z(:,:) ! Out: Eigenvectors
 
-    real    :: work(max(1,2*size(d)-2))
-    integer :: info
-    integer :: nz1, nz2
+    real(srk) :: work(max(1,2*size(d)-2))
+    integer   :: info      ! Must be of default integer kind
+    integer   :: nz1, nz2  ! Must be of default integer kind
     
     nz1 = size(z,dim=1) ; nz2 = size(z,dim=2)
     call sstev('V',size(d),d,e,z(1:nz1,1:nz2),nz1,work,info)
@@ -210,15 +274,15 @@ module lapack
   end subroutine lapack_sstev
 
   subroutine lapack_dstev(d,e,z)
-    double precision, intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
+    real(drk), intent(inout) :: d(:)   ! In:  Diagonal elements of the matrix 
                                               ! Out: Eigenvalues, ascending order
-    double precision, intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
+    real(drk), intent(inout) :: e(:)   ! In:  Sub-/super-diagonal elements of the matrix
                                               ! Out: Destroyed
-    double precision, intent(out)   :: z(:,:) ! Out: Eigenvectors
+    real(drk), intent(out)   :: z(:,:) ! Out: Eigenvectors
 
-    double precision :: work(max(1,2*size(d)-2))
-    integer          :: info
-    integer          :: nz1, nz2
+    real(drk) :: work(max(1,2*size(d)-2))
+    integer   :: info      ! Must be of default integer kind
+    integer   :: nz1, nz2  ! Must be of default integer kind
     
     nz1 = size(z,dim=1) ; nz2 = size(z,dim=2)
     call dstev('V',size(d),d,e,z(1:nz1,1:nz2),nz1,work,info)
@@ -230,16 +294,16 @@ module lapack
   end subroutine lapack_dstev
 
   subroutine lapack_cgeev(h,e)
-    complex, intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
-                                      ! Out: Eigenvectors
-    complex, intent(out)   :: e(:)    ! Out: Eigenvalues
+    complex(srk), intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
+                                           ! Out: Eigenvectors
+    complex(srk), intent(out)   :: e(:)    ! Out: Eigenvalues
 
-    complex :: work(50*size(h,dim=2))
-    real    :: rwork(3*size(h,dim=2))
-    complex :: vl(1,1)
-    complex :: vr(size(h,dim=2),size(h,dim=2))
-    integer :: info
-    integer :: nh1, nh2
+    complex(srk) :: work(50*size(h,dim=2))
+    real(srk)    :: rwork(3*size(h,dim=2))
+    complex(srk) :: vl(1,1)
+    complex(srk) :: vr(size(h,dim=2),size(h,dim=2))
+    integer      :: info      ! Must be of default integer kind
+    integer      :: nh1, nh2  ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call cgeev('N','V',nh2,h(1:nh1,1:nh2),nh1,e(:),vl,1,vr,nh2,work,size(work),rwork,info)
@@ -255,12 +319,12 @@ module lapack
                                              ! Out: Eigenvectors
     complex(kind=drk), intent(out)   :: e(:)    ! Out: Eigenvalues
 
-    complex(kind=drk)   :: work(50*size(h,dim=2))
-    double precision :: rwork(3*size(h,dim=2))
-    complex(kind=drk)   :: vl(1,1)
-    complex(kind=drk)   :: vr(size(h,dim=2),size(h,dim=2))
-    integer :: info
-    integer :: nh1, nh2
+    complex(kind=drk) :: work(50*size(h,dim=2))
+    real(drk)         :: rwork(3*size(h,dim=2))
+    complex(kind=drk) :: vl(1,1)
+    complex(kind=drk) :: vr(size(h,dim=2),size(h,dim=2))
+    integer           :: info     ! Must be of default integer kind
+    integer           :: nh1, nh2 ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call zgeev('N','V',nh2,h(1:nh1,1:nh2),nh1,e(:),vl,1,vr,nh2,work,size(work),rwork,info)
@@ -271,15 +335,59 @@ module lapack
     h(1:nh2,1:nh2) = vr
   end subroutine lapack_zgeev
 
-  subroutine lapack_cheev(h,e)
-    complex, intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
-                                      ! Out: Eigenvectors
-    real, intent(out)   :: e(:)       ! Out: Eigenvalues
+  subroutine lapack_zgeev2(h,e)
+    complex(kind=drk), intent(inout) :: h(:,:,:) ! In:  h(:,:,1) = hermitian matrix to be diagonalized
+                                                 ! Out: h(:,:,1) = Left eigenvectors
+                                                 !      h(:,:,2) = Right eigenvectors
+    complex(kind=drk), intent(out)   :: e(:)     ! Out: Eigenvalues
 
-    complex :: work(50*size(h,dim=1))
-    real    :: rwork(3*size(h,dim=1))
-    integer :: info
-    integer :: nh1, nh2
+    complex(kind=drk) :: work(50*size(h,dim=2))
+    real(drk)         :: rwork(3*size(h,dim=2))
+    complex(kind=drk) :: vl(size(h,dim=2),size(h,dim=2))
+    integer           :: info     ! Must be of default integer kind
+    integer           :: nh1, nh2 ! Must be of default integer kind
+    
+    nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
+    if (nh1<nh2) stop 'lapack_zgeev2 - oops'
+    call zgeev('V','V',nh2,h(1:nh1,1:nh2,1),nh1,e(:),vl,nh2,h(1:nh1,1:nh2,2),nh1,work,size(work),rwork,info)
+    if (info/=0) then
+      write (out,"(' zgeev returned ',i8)") info
+      stop 'lapack_zgeev2 - zgeev failed'
+    end if
+    h(1:nh2,1:nh2,1) = vl
+  end subroutine lapack_zgeev2
+
+!*qd subroutine lapack_quad_zgeev2(h,e)
+!*qd   complex(qrk), intent(inout) :: h(:,:,:) ! In:  h(:,:,1) = hermitian matrix to be diagonalized
+!*qd                                           ! Out: h(:,:,1) = Left eigenvectors
+!*qd                                           !      h(:,:,2) = Right eigenvectors
+!*qd   complex(qrk), intent(out)   :: e(:)     ! Out: Eigenvalues
+   
+!*qd   complex(qrk) :: work(50*size(h,dim=2))
+!*qd   real(qrk)    :: rwork(3*size(h,dim=2))
+!*qd   complex(qrk) :: vl(size(h,dim=2),size(h,dim=2))
+!*qd   integer      :: info      ! Must be of default integer kind
+!*qd   integer      :: nh1, nh2  ! Must be of default integer kind
+!*qd   
+!*qd   nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
+!*qd   if (nh1<nh2) stop 'lapack%lapack_quad_zgeev2 - oops'
+!*qd   call quad_zgeev('V','V',nh2,h(1:nh1,1:nh2,1),nh1,e(:),vl,nh2,h(1:nh1,1:nh2,2),nh1,work,size(work),rwork,info)
+!*qd   if (info/=0) then
+!*qd     write (out,"(' quad_zgeev returned ',i8)") info
+!*qd     stop 'lapack%lapack_quad_zgeev2 - quad_zgeev failed'
+!*qd   end if
+!*qd   h(1:nh2,1:nh2,1) = vl
+!*qd end subroutine lapack_quad_zgeev2
+
+  subroutine lapack_cheev(h,e)
+    complex(srk), intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
+                                           ! Out: Eigenvectors
+    real(srk), intent(out)   :: e(:)       ! Out: Eigenvalues
+
+    complex(srk) :: work(50*size(h,dim=1))
+    real(srk)    :: rwork(3*size(h,dim=1))
+    integer      :: info                   ! Must be of default integer kind
+    integer      :: nh1, nh2               ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call cheev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),rwork,info)
@@ -290,14 +398,14 @@ module lapack
   end subroutine lapack_cheev
 
   subroutine lapack_zheev(h,e)
-    complex(kind=drk), intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
-                                             ! Out: Eigenvectors
-    double precision, intent(out)   :: e(:)  ! Out: Eigenvalues
+    complex(drk), intent(inout) :: h(:,:)  ! In:  Hermitian matrix to be diagonalized
+                                           ! Out: Eigenvectors
+    real(drk), intent(out)   :: e(:)       ! Out: Eigenvalues
 
-    complex(kind=drk)   :: work(50*size(h,dim=1))
-    double precision :: rwork(3*size(h,dim=1))
-    integer          :: info
-    integer          :: nh1, nh2
+    complex(drk) :: work(50*size(h,dim=1))
+    real(drk)    :: rwork(3*size(h,dim=1))
+    integer      :: info            ! Must be of default integer kind
+    integer      :: nh1, nh2        ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call zheev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),rwork,info)
@@ -308,13 +416,13 @@ module lapack
   end subroutine lapack_zheev
 
   subroutine lapack_dsyev(h,e)
-    double precision, intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
+    real(drk), intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
                                                ! Out: Eigenvectors
-    double precision, intent(out)   :: e(:)    ! Out: Eigenvalues
+    real(drk), intent(out)   :: e(:)    ! Out: Eigenvalues
 
-    double precision :: work(50*size(h,dim=1))
-    integer          :: info
-    integer          :: nh1, nh2
+    real(drk) :: work(50*size(h,dim=1))
+    integer   :: info      ! Must be of default integer kind
+    integer   :: nh1, nh2  ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call dsyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
@@ -324,14 +432,31 @@ module lapack
     end if
   end subroutine lapack_dsyev
 
-  subroutine lapack_ssyev(h,e)
-    real, intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
-                                   ! Out: Eigenvectors
-    real, intent(out)   :: e(:)    ! Out: Eigenvalues
+!*qd subroutine lapack_quad_dsyev(h,e)
+!*qd   real(qrk), intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
+!*qd                                       ! Out: Eigenvectors
+!*qd   real(qrk), intent(out)   :: e(:)    ! Out: Eigenvalues
+   
+!*qd   real(qrk) :: work(50*size(h,dim=1))
+!*qd   integer   :: info       ! Must be of default integer kind
+!*qd   integer   :: nh1, nh2   ! Must be of default integer kind
+!*qd   
+!*qd   nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
+!*qd   call quad_dsyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
+!*qd   if (info/=0) then
+!*qd     write (out,"(' quad_dsyev returned ',i8)") info
+!*qd     stop 'lapack_quad_dsyev - dsyev failed'
+!*qd   end if
+!*qd end subroutine lapack_quad_dsyev
 
-    real             :: work(50*size(h,dim=1))
-    integer          :: info
-    integer          :: nh1, nh2
+  subroutine lapack_ssyev(h,e)
+    real(srk), intent(inout) :: h(:,:)  ! In:  symmetric matrix to be diagonalized
+                                        ! Out: Eigenvectors
+    real(srk), intent(out)   :: e(:)    ! Out: Eigenvalues
+
+    real(srk)        :: work(50*size(h,dim=1))
+    integer          :: info       ! Must be of default integer kind
+    integer          :: nh1, nh2   ! Must be of default integer kind
     
     nh1 = size(h,dim=1) ; nh2 = size(h,dim=2)
     call ssyev('V','U',nh1,h(1:nh1,1:nh2),nh1,e(:),work,size(work),info)
@@ -342,19 +467,19 @@ module lapack
   end subroutine lapack_ssyev
 
   subroutine lapack_dgesvd(a,s,u,vth)
-    double precision, intent(inout) :: a  (:,:)  ! In:  Matrix to be decomposed
-                                                 ! Out: Content destroyed
-    double precision, intent(out)   :: s  (:)    ! Out: Singular values
-    double precision, intent(out)   :: u  (:,:)  ! Out: Left singular vectors
-    double precision, intent(out)   :: vth(:,:)  ! Out: Right singular vectors, transposed & conjugated
-                                                 ! The overall result is A = U S VTH
+    real(drk), intent(inout) :: a  (:,:)  ! In:  Matrix to be decomposed
+                                          ! Out: Content destroyed
+    real(drk), intent(out)   :: s  (:)    ! Out: Singular values
+    real(drk), intent(out)   :: u  (:,:)  ! Out: Left singular vectors
+    real(drk), intent(out)   :: vth(:,:)  ! Out: Right singular vectors, transposed & conjugated
+                                          ! The overall result is A = U S VTH
 
-    character(len=1)              :: jobu        ! Either 'A' (all) or 'S' (singular), depending on the
-    character(len=1)              :: jobvth      ! sizes of u and vth arrays
-    double precision              :: lwq(1)
-    double precision, allocatable :: work(:)
-    integer                       :: info, lwork
-    integer                       :: m, n, lda, ldu, ldvth, nsing
+    character(len=1)       :: jobu        ! Either 'A' (all) or 'S' (singular), depending on the
+    character(len=1)       :: jobvth      ! sizes of u and vth arrays
+    real(drk)              :: lwq(1)
+    real(drk), allocatable :: work(:)
+    integer                :: info, lwork                    ! Must be of default integer kind
+    integer                :: m, n, lda, ldu, ldvth, nsing   ! Must be of default integer kind
    
     m     = size(a,dim=1) 
     n     = size(a,dim=2) 
@@ -399,15 +524,15 @@ module lapack
   subroutine lapack_zgesvd(a,s,u,vth)
     complex(kind=drk), intent(inout) :: a  (:,:)  ! In:  Matrix to be decomposed
                                                   ! Out: Content destroyed
-    double precision, intent(out)    :: s  (:)    ! Out: Singular values
+    real(drk), intent(out)    :: s  (:)    ! Out: Singular values
     complex(kind=drk), intent(out)   :: u  (:,:)  ! Out: Left singular vectors
     complex(kind=drk), intent(out)   :: vth(:,:)  ! Out: Right singular vectors, transposed & conjugated
                                                   ! The overall result is A = U S VTH
 
-    complex(kind=drk)   :: work(50*max(size(a,dim=1),size(a,dim=2)))
-    double precision :: rwork(5*size(a,dim=1))
-    integer          :: info, lwork
-    integer          :: m, n, lda, ldu, ldvth
+    complex(drk) :: work(50*max(size(a,dim=1),size(a,dim=2)))
+    real(drk)    :: rwork(5*size(a,dim=1))
+    integer      :: info, lwork           ! Must be of default integer kind
+    integer      :: m, n, lda, ldu, ldvth ! Must be of default integer kind
    
     m     = size(a,dim=1) ; lda = m
     n     = size(a,dim=2) 
@@ -426,13 +551,13 @@ module lapack
   end subroutine lapack_zgesvd
 
   subroutine lapack_dsterf(a,b)
-    double precision, intent(inout) :: a(:) ! In: Diagonal elements of the tri-diagonal matrix
+    real(drk), intent(inout) :: a(:) ! In: Diagonal elements of the tri-diagonal matrix
                                             ! Out: Eigenvalues, in the ascending order
-    double precision, intent(inout) :: b(:) ! In: Sub-diagonal elements of the tri-diagonal matirx
+    real(drk), intent(inout) :: b(:) ! In: Sub-diagonal elements of the tri-diagonal matirx
                                             ! Out: Destroyed
     !
-    integer :: na, nb
-    integer :: info
+    integer :: na, nb ! Must be of default integer kind
+    integer :: info   ! Must be of default integer kind
     !
     na = size(a)
     nb = size(b)
@@ -448,13 +573,13 @@ module lapack
   end subroutine lapack_dsterf
 
   subroutine lapack_ssterf(a,b)
-    real, intent(inout) :: a(:) ! In: Diagonal elements of the tri-diagonal matrix
-                                ! Out: Eigenvalues, in the ascending order
-    real, intent(inout) :: b(:) ! In: Sub-diagonal elements of the tri-diagonal matirx
-                                ! Out: Destroyed
+    real(srk), intent(inout) :: a(:) ! In: Diagonal elements of the tri-diagonal matrix
+                                     ! Out: Eigenvalues, in the ascending order
+    real(srk), intent(inout) :: b(:) ! In: Sub-diagonal elements of the tri-diagonal matirx
+                                     ! Out: Destroyed
     !
-    integer :: na, nb
-    integer :: info
+    integer :: na, nb  ! Must be of default integer kind
+    integer :: info    ! Must be of default integer kind
     !
     na = size(a)
     nb = size(b)
@@ -470,15 +595,15 @@ module lapack
   end subroutine lapack_ssterf
 
   subroutine lapack_ginverse_real(amat,power_)
-    real, intent(inout)        :: amat(:,:) ! In: matrix to invert
-                                            ! Out: generalized inverse of the matrix
-    real, intent(in), optional :: power_    ! In: power of the inverse; 1/2 if omitted
-                                            !     (corresponding to A^(-1))
+    real(srk), intent(inout)        :: amat(:,:) ! In: matrix to invert
+                                                 ! Out: generalized inverse of the matrix
+    real(srk), intent(in), optional :: power_    ! In: power of the inverse; 1/2 if omitted
+                                                 !     (corresponding to A^(-1))
     !
-    real :: eval(size(amat,dim=1))
-    real :: evec(size(amat,dim=1),size(amat,dim=1))
-    real :: eps
-    real :: power
+    real(srk) :: eval(size(amat,dim=1))
+    real(srk) :: evec(size(amat,dim=1),size(amat,dim=1))
+    real(srk) :: eps
+    real(srk) :: power
     !
     power = 0.5
     if (present(power_)) power = power_
@@ -497,15 +622,15 @@ module lapack
   end subroutine lapack_ginverse_real
 
   subroutine lapack_ginverse_complex(amat,power_)
-    complex, intent(inout)     :: amat(:,:) ! In: matrix to invert
-                                            ! Out: generalized inverse of the matrix
-    real, intent(in), optional :: power_    ! In: power of the inverse; 1/2 if omitted
-                                            !     (corresponding to A^(-1))
+    complex(srk), intent(inout)     :: amat(:,:) ! In: matrix to invert
+                                                 ! Out: generalized inverse of the matrix
+    real(srk), intent(in), optional :: power_    ! In: power of the inverse; 1/2 if omitted
+                                                 !     (corresponding to A^(-1))
     !
-    real    :: eval(size(amat,dim=1))
-    complex :: evec(size(amat,dim=1),size(amat,dim=1))
-    real    :: eps
-    real    :: power
+    real(srk)    :: eval(size(amat,dim=1))
+    complex(srk) :: evec(size(amat,dim=1),size(amat,dim=1))
+    real(srk)    :: eps
+    real(srk)    :: power
     !
     power = 0.5
     if (present(power_)) power = power_
@@ -524,15 +649,15 @@ module lapack
   end subroutine lapack_ginverse_complex
 
   subroutine lapack_ginverse_double(amat,power_)
-    double precision, intent(inout) :: amat(:,:)     ! In: matrix to invert
+    real(drk), intent(inout) :: amat(:,:)     ! In: matrix to invert
                                                      ! Out: generalized inverse of the matrix
-    double precision, intent(in), optional :: power_ ! In: power of the inverse; 1/2 if omitted
+    real(drk), intent(in), optional :: power_ ! In: power of the inverse; 1/2 if omitted
                                                      !     (corresponding to A^(-1))
 
-    double precision :: eval(size(amat,dim=1))
-    double precision :: evec(size(amat,dim=1),size(amat,dim=1))
-    double precision :: eps
-    double precision :: power
+    real(drk) :: eval(size(amat,dim=1))
+    real(drk) :: evec(size(amat,dim=1),size(amat,dim=1))
+    real(drk) :: eps
+    real(drk) :: power
     !
     power = 0.5d0
     if (present(power_)) power = power_
@@ -553,13 +678,13 @@ module lapack
   subroutine lapack_ginverse_doublecomplex(amat,power_)
     complex(kind=drk), intent(inout)     :: amat(:,:)   ! In: matrix to invert
                                                      ! Out: generalized inverse of the matrix
-    double precision, intent(in), optional :: power_ ! In: power of the inverse; 1/2 if omitted
+    real(drk), intent(in), optional :: power_ ! In: power of the inverse; 1/2 if omitted
                                                      !     (corresponding to A^(-1))
     !
-    double precision :: eval(size(amat,dim=1))
+    real(drk) :: eval(size(amat,dim=1))
     complex(kind=drk)   :: evec(size(amat,dim=1),size(amat,dim=1))
-    double precision :: eps
-    double precision :: power
+    real(drk) :: eps
+    real(drk) :: power
     !
     power = 0.5d0
     if (present(power_)) power = power_
@@ -577,16 +702,124 @@ module lapack
     !
   end subroutine lapack_ginverse_doublecomplex
 
-  function linpack_determinant_double(mat) result(det)
-    double precision, intent(in)  :: mat(:,:) ! Matrix to compute determinant for
-    double precision              :: det
+  subroutine lapack_zgesv(a,b)
+    complex(drk), intent(inout) :: a(:,:) ! In: Linear system matrix
+                                          ! Out: Destroyed
+    complex(drk), intent(inout) :: b(:,:) ! In: Right-half side
+                                          ! Out: Solutions
     !
-    double precision, allocatable :: tm(:,:)
-    integer                       :: order, info
-    integer                       :: ipvt(size(mat,dim=1))
-    double precision              :: work(size(mat,dim=1))
-    double precision              :: detx(2)
-    external                      :: dgefa, dgedi
+    integer(ik) :: info, n, nrhs, lda, ldb
+    integer(ik) :: ipiv(size(a,dim=2))
+    !
+    n    = size(a,dim=2)
+    nrhs = size(b,dim=2)
+    lda  = size(a,dim=1)
+    ldb  = size(b,dim=1)
+    if (lda<n .or. ldb<n) stop 'lapack%lapack_zgesv - crazy inputs'
+    call zgesv(n,nrhs,a,lda,ipiv,b,ldb,info)
+    if (info/=0) then
+      write (out,"('lapack%lapack_zgesv failed with code ',i0)") info
+      stop 'lapack%lapack_zgesv failed'
+    end if
+  end subroutine lapack_zgesv
+
+!*qd subroutine lapack_quad_zgesv(a,b)
+!*qd   complex(qrk), intent(inout) :: a(:,:) ! In: Linear system matrix
+!*qd                                         ! Out: Destroyed
+!*qd   complex(qrk), intent(inout) :: b(:,:) ! In: Right-half side
+!*qd                                         ! Out: Solutions
+!*qd   !
+!*qd   integer(ik) :: info, n, nrhs, lda, ldb
+!*qd   integer(ik) :: ipiv(size(a,dim=2))
+!*qd   !
+!*qd   n    = size(a,dim=2)
+!*qd   nrhs = size(b,dim=2)
+!*qd   lda  = size(a,dim=1)
+!*qd   ldb  = size(b,dim=1)
+!*qd   if (lda<n .or. ldb<n) stop 'lapack%lapack_quad_zgesv - crazy inputs'
+!*qd   call quad_zgesv(n,nrhs,a,lda,ipiv,b,ldb,info)
+!*qd   if (info/=0) then
+!*qd     write (out,"('lapack%lapack_quad_zgesv failed with code ',i0)") info
+!*qd     stop 'lapack%lapack_quad_zgesv failed'
+!*qd   end if
+!*qd end subroutine lapack_quad_zgesv
+
+  function lapack_determinant_double(mat) result(det)
+    real(drk), intent(in)  :: mat(:,:) ! Matrix to compute determinant for
+    real(drk)              :: det
+    !
+    real(drk), allocatable :: tm(:,:)
+    integer                :: order, info ! Must be of default integer kind
+    integer, allocatable   :: ipiv(:)     ! Must be of default integer kind
+    integer(ik)            :: i
+    !
+    order = size(mat,dim=1)
+    if (order<=0) stop 'lapack%lapack_determinant_double - zero-size matrix'
+    if (size(mat,dim=2)/=order) stop 'lapack%lapack_determinant_double - matrix not square'
+    !
+    allocate (tm(order,order),ipiv(order),stat=info)
+    if (info/=0) stop 'lapack%lapack_determinant_double - no memory'
+    !
+    tm = mat
+    call dgetrf(order,order,tm,order,ipiv,info)
+    if (info<0) stop 'lapack%lapack_determinant_double - dgetrf failed'
+    !
+    det = 1
+    compute_determinant: do i=1,order
+      det = det * tm(i,i)
+      if (ipiv(i)/=i) det = -det
+    end do compute_determinant
+    !
+    deallocate(tm,ipiv,stat=info)
+    if (info/=0) stop 'lapack%lapack_determinant_double - memory deallocation failed'
+    !
+    ! write (out,"('DEBUG: double lapack det = ',g30.20,' diff from linpack = ',g30.20)") &
+    !        det, det - linpack_determinant_double(mat)
+  end function lapack_determinant_double
+  !
+!*qd function lapack_determinant_quad(mat) result(det)
+!*qd   real(qrk), intent(in)  :: mat(:,:)    ! Matrix to compute determinant for
+!*qd   real(qrk)              :: det
+!*qd   !
+!*qd   real(qrk), allocatable :: tm(:,:)
+!*qd   integer                :: order, info ! Must be of default integer kind
+!*qd   integer, allocatable   :: ipiv(:)     ! Must be of default integer kind
+!*qd   integer(ik)            :: i
+!*qd   !
+!*qd   order = size(mat,dim=1)
+!*qd   if (order<=0) stop 'lapack%lapack_determinant_quad - zero-size matrix'
+!*qd   if (size(mat,dim=2)/=order) stop 'lapack%lapack_determinant_quad - matrix not square'
+!*qd   !
+!*qd   allocate (tm(order,order),ipiv(order),stat=info)
+!*qd   if (info/=0) stop 'lapack%lapack_determinant_quad - no memory'
+!*qd   !
+!*qd   tm = mat
+!*qd   call quad_dgetrf(order,order,tm,order,ipiv,info)
+!*qd   if (info<0) stop 'lapack%lapack_determinant_quad - dgetrf failed'
+!*qd   !
+!*qd   det = 1
+!*qd   compute_determinant: do i=1,order
+!*qd     det = det * tm(i,i)
+!*qd     if (ipiv(i)/=i) det = -det
+!*qd   end do compute_determinant
+!*qd   !
+!*qd   deallocate(tm,ipiv,stat=info)
+!*qd   if (info/=0) stop 'lapack%lapack_determinant_quad - memory deallocation failed'
+!*qd   !
+!*qd   ! write (out,"('DEBUG: quad lapack det = ',g30.20,' diff from linpack = ',g30.20)") &
+!*qd   !        det, det - linpack_determinant_double(real(mat,kind=drk))
+!*qd end function lapack_determinant_quad
+  !
+  function linpack_determinant_double(mat) result(det)
+    real(drk), intent(in)  :: mat(:,:) ! Matrix to compute determinant for
+    real(drk)              :: det
+    !
+    real(drk), allocatable :: tm(:,:)
+    integer                :: order, info            ! Must be of default integer kind
+    integer                :: ipvt(size(mat,dim=1))  ! Must be of default integer kind
+    real(drk)              :: work(size(mat,dim=1))
+    real(drk)              :: detx(2)
+    external               :: dgefa, dgedi
     !
     order = size(mat,dim=1)
     if (size(mat,dim=2)/=order) then
@@ -619,5 +852,34 @@ module lapack
     !
     det = detx(1) * 10.0d0**detx(2)
   end function linpack_determinant_double
+
+  function linpack_determinant_double_trash_input(mat) result(det)
+    real(drk), intent(inout)  :: mat(:,:) ! Matrix to compute determinant for
+    real(drk)                 :: det
+    !
+    integer                   :: order, info            ! Must be of default integer kind
+    integer                   :: ipvt(size(mat,dim=1))  ! Must be of default integer kind
+    real(drk)                 :: work(size(mat,dim=1))
+    real(drk)                 :: detx(2)
+    external                  :: dgefa, dgedi
+    !
+    order = size(mat,dim=1)
+    if (size(mat,dim=2)/=order) then
+      write (out,"('Determinant requested for a non-square matrix: ',2i5,'. Bummer.')") &
+             order, size(mat,dim=2)
+      stop 'lapack%linpack_determinant_double_trash - bad input'
+    end if
+    !
+    call dgefa(mat,order,order,ipvt,info)
+    if (info>0) then
+      !  Zero pivot; determinant vanishes
+      det = 0
+      return
+    end if
+    !
+    call dgedi(mat,order,order,ipvt,detx,work,10)
+    !
+    det = detx(1) * 10.0d0**detx(2)
+  end function linpack_determinant_double_trash_input
 
 end module lapack

--- a/math.f90
+++ b/math.f90
@@ -229,7 +229,7 @@ module math
     cnm = exp(real(MathLogGamma(n+one)-MathLogGamma(n-m+one)-MathLogGamma(m+one),kind=rk))
   end function MathBinomialReal
   !
-  !  Evaluate log(exp(a)+exp(b)), where a and b may be too large to fit 
+  !  Evaluate log(exp(a)+exp(b)), where a and b may be too large to fit
   !  in the exponent range.
   !
   function MathLogSum(a,b) result(c)
@@ -331,7 +331,7 @@ module math
   !
   function Math3J(j1,j2,j3,m1,m2,m3) result(v)
     integer(ik), intent(in) :: j1, j2, j3  ! / J1 J2 J3 \ 3-j
-    integer(ik), intent(in) :: m1, m2, m3  ! \ M1 M2 M3 / 
+    integer(ik), intent(in) :: m1, m2, m3  ! \ M1 M2 M3 /
     real(rk)                :: v
     !
     integer(ik) :: ij0, ij1, ij2, ij3, im1a, im1b, im2a, im2b, im3a, im3b
@@ -383,7 +383,7 @@ module math
     !
   end function Math3J
   !
-  !  Given Euler angles, construct rotation matrix for coordinate axes 
+  !  Given Euler angles, construct rotation matrix for coordinate axes
   !  in 3D space.  The Euler angles are defined as follows:
   !   1. Rotate coordinate axes by alpha around the Z axis
   !   2. Rotate axes by beta around the new Y axis
@@ -391,7 +391,7 @@ module math
   !  This definition of the Euler angles matches the definition from
   !  section 58 of L&L III.
   !
-  !  Note that prior to June 10th, 2010 the definition of all three Euler 
+  !  Note that prior to June 10th, 2010 the definition of all three Euler
   !  angles in this routine used a wrong sign, corresponding to anti-screw
   !  rotation sense. Thanks, Mike.
   !
@@ -401,13 +401,13 @@ module math
   !
   !  Some useful special cases are:
   !
-  !    a     b     c  
-  !   ---   ---   --- 
+  !    a     b     c
+  !   ---   ---   ---
   !    x     0     0   Rotate coordinate system by x around the Z axis
   !    0     0     x   Rotate coordinate system by x around the Z axis
   !    0     x     0   Rotate coordinate system by x around the Y axis
   !  -pi/2   x   pi/2  Rotate coordinate system by x around the X axis
-  !      
+  !
   subroutine MathRotationMatrix(euler_angles,mat)
     real(ark), intent(in)  :: euler_angles(3) ! Euler rotation angles: alpha, beta, and gamma
     real(ark), intent(out) :: mat(3,3)        ! Rotation matrix
@@ -443,7 +443,7 @@ module math
   !  Note that the rotation matrix uses somewhat weird conventions: it rotates transposed
   !  harmonics from the primed coordinate system defined by the Euler angles back into
   !  the lab system:
-  !  
+  !
   !    Y(L,M) = Sum Y(L,M') D(M',M)
   !
   !  Furthermore, it looks like the expression for the Wigner matrix in the 5th Russian
@@ -476,7 +476,7 @@ module math
     g = euler_angles(3)
     !
     !  We need to take special care when angle beta approaches n*pi. For these angles,
-    !  
+    !
     !
     sinb2 = sin(0.5_ark*b)
     cosb2 = cos(0.5_ark*b)
@@ -514,7 +514,7 @@ module math
     !    y^a x^b JacobiP(n,a,b,x^2-y^2)
     !
     !  where x^2+y^2 is equal to 1. Care should be taken in evaluating this function
-    !  when either a or b are negative: standard recursion with respect to degree 
+    !  when either a or b are negative: standard recursion with respect to degree
     !  becomes undefined in this case.
     !
     !  As the result, we have to use series expansion around +1/-1 argument to
@@ -538,7 +538,7 @@ module math
         end do expand_plus1
         jp = x**b * jp / MathFactorial(n)
 !       write (out,"(a,3(1x,i3),3(1x,f35.25))") 'A: ',n,a,b,y,x,jp
-      else 
+      else
         !
         !  Small x, expand JacobiP around z=-1
         !
@@ -567,7 +567,7 @@ module math
     integer(ik) :: i
     !
     if (size(m,dim=1)/=size(m,dim=2)) then
-      write (out,"('math%MathSetUnitMatrix - argument is not a square matrix?!')") 
+      write (out,"('math%MathSetUnitMatrix - argument is not a square matrix?!')")
       stop 'math%MathSetUnitMatrix - argument is not a square matrix?!'
     end if
     !
@@ -583,7 +583,7 @@ module math
     integer(ik) :: i
     !
     if (size(m,dim=1)/=size(m,dim=2)) then
-      write (out,"('math%MathSetUnitMatrix - argument is not a square matrix?!')") 
+      write (out,"('math%MathSetUnitMatrix - argument is not a square matrix?!')")
       stop 'math%MathSetUnitMatrix - argument is not a square matrix?!'
     end if
     !
@@ -599,7 +599,7 @@ module math
     real(ark), intent(in) :: m(:,:) ! Matrix to check
     logical               :: isunit
     !
-    real(kind=kind(m))    :: eps 
+    real(kind=kind(m))    :: eps
     integer(ik)           :: i, j
     !
     eps = spacing(real(2,kind=kind(m)))
@@ -622,7 +622,7 @@ module math
     real(xrk), intent(in) :: m(:,:) ! Matrix to check
     logical               :: isunit
     !
-    real(kind=kind(m))    :: eps 
+    real(kind=kind(m))    :: eps
     integer(ik)           :: i, j
     !
     eps = spacing(real(2,kind=kind(m)))
@@ -721,7 +721,7 @@ module math
         mu0 = real(MathSimpleGamma(cmplx(1._rk + alpha,0._rk,kind=rk)),kind=rk)
     end select
     !
-    call lapack_stev(a,b,z)  
+    call lapack_stev(a,b,z)
     !
     !  Copy integration abscissas and weights, and we are done
     !
@@ -922,7 +922,7 @@ module math
     !
     allocate (factorial_table(0:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element factorial table')") &
              alloc, nmax
       stop 'math%fill_factorial_table - allocate'
     end if
@@ -964,7 +964,7 @@ module math
     !
     allocate (factorial_quad_table(0:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element factorial table')") &
              alloc, nmax
       stop 'math%fill_factorial_quad_table - allocate'
     end if
@@ -1006,7 +1006,7 @@ module math
     !
     allocate (log_factorial_table(0:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element log-factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element log-factorial table')") &
              alloc, nmax
       stop 'math%fill_log_factorial_table - allocate'
     end if
@@ -1044,7 +1044,7 @@ module math
     !
     allocate (log_factorial_quad_table(0:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element log-factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element log-factorial table')") &
              alloc, nmax
       stop 'math%fill_log_factorial_quad_table - allocate'
     end if
@@ -1078,7 +1078,7 @@ module math
     !
     allocate (dfactorial_table(-1:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element double factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element double factorial table')") &
              alloc, nmax
       stop 'math%fill_dfactorial_table - allocate'
     end if
@@ -1115,7 +1115,7 @@ module math
     !
     allocate (dfactorial_quad_table(-1:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element double factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element double factorial table')") &
              alloc, nmax
       stop 'math%fill_dfactorial_quad_table - allocate'
     end if
@@ -1152,7 +1152,7 @@ module math
     !
     allocate (log_dfactorial_table(-1:nmax),stat=alloc)
     if (alloc/=0) then
-      write (out,"('Error ',i10,' allocating ',i10,'-element log-double factorial table')") & 
+      write (out,"('Error ',i10,' allocating ',i10,'-element log-double factorial table')") &
              alloc, nmax
       stop 'math%fill_log_dfactorial_table - allocate'
     end if
@@ -1214,7 +1214,7 @@ module math
     ! write (out,"(' zcut = ',f25.15)") zcut
     logs = 0._rk
     zr   = z
-    inflate_z: do while(abs(zr)<zcut) 
+    inflate_z: do while(abs(zr)<zcut)
       logs = logs + log(zr*(zr+1)*(zr+2))
       zr   = zr + 3
     end do inflate_z
@@ -1242,7 +1242,7 @@ module math
     v = erf (x)
   end function MathErf
   !
-  !  MathBoysF implements the integral of x**(2*n)*Exp(-t*x**2) for x between 0 and 1. 
+  !  MathBoysF implements the integral of x**(2*n)*Exp(-t*x**2) for x between 0 and 1.
   !  Depending on the arguments, the implementation will switch between:
   !   a. (large t) Asymptotic form of the integral (with the upper bound replaced by infinity)
   !   b. (small t) Explicit power series
@@ -1268,7 +1268,7 @@ module math
     integer(ik)            :: safe_n            ! Min. order safe for explict summation
     real(rk)               :: safe_f            ! Boys' function for the safe order
     real(rk)               :: safe_f_term       ! Current term in the Boys' function
-    integer(ik)            :: i                 ! 
+    integer(ik)            :: i                 !
     !
     !  Try to use the asymptotic formula first
     !
@@ -1336,7 +1336,7 @@ module math
     integer(ik)            :: safe_n            ! Min. order safe for explict summation
     real(xrk)              :: safe_f            ! Boys' function for the safe order
     real(xrk)              :: safe_f_term       ! Current term in the Boys' function
-    integer(ik)            :: i                 ! 
+    integer(ik)            :: i                 !
     !
     !  Try to use the asymptotic formula first
     !
@@ -1392,11 +1392,11 @@ module math
     g = sqrt(pi_xrk) * MathDoubleFactorial(2*n-1,g) / 2._xrk**n
   end function gamma_n_plus_half_quad
   !
-  !  Determinant and inverse of a 3x3 matrix are so common that it makes 
+  !  Determinant and inverse of a 3x3 matrix are so common that it makes
   !  sense to code these explicitly. See lapack.f90 for the general case.
   !
   function MathDet3x3Real(m) result(d)
-    real(rk), intent(in) :: m(3,3) ! Matrix for which we need the determinant; 
+    real(rk), intent(in) :: m(3,3) ! Matrix for which we need the determinant;
                                    ! it seems wasteful to call general routines in lapack.f90 for this.
     real(rk)             :: d
     !
@@ -1421,7 +1421,7 @@ module math
   end function MathInv3x3Real
   !
   function MathDet3x3Complex(m) result(d)
-    complex(rk), intent(in) :: m(3,3) ! Matrix for which we need the determinant; 
+    complex(rk), intent(in) :: m(3,3) ! Matrix for which we need the determinant;
                                       ! it seems wasteful to call general routines in lapack.f90 for this.
     complex(rk)             :: d
     !
@@ -1466,7 +1466,7 @@ module math
   !
   function MathDawsonF(z) result(f)
     real(rk), intent(in)   :: z ! Argument to evaluate Dawson's integral for
-    real(rk)               :: f 
+    real(rk)               :: f
     !
     real(rk), parameter    :: magic_h = 1.03517084701_rk      ! pi/(2*sqrt(log(10.)))
     real(rk), parameter    :: sqrt_nn = 6._rk                 ! sqrt(number of significant digits desired)
@@ -1488,7 +1488,7 @@ module math
     real(rk)    :: z2    ! z**2
     real(rk)    :: zcorr ! z - n0*h
     real(rk)    :: n0    ! Central value of n, giving the largest term in the sum
-                         ! This needs to be real to avoid an integer overflow for 
+                         ! This needs to be real to avoid an integer overflow for
                          ! large arguments
     real(rk)    :: n
     integer(ik) :: dn

--- a/molecular_grid.f90
+++ b/molecular_grid.f90
@@ -1,4 +1,7 @@
 !
+!  * 2013 Oct 25 - Added support for integrating outer-sphere operators
+!  * 2013 Apr 26 - Added support for ring singularity of a square-root type.
+!
 !  Simple non-uniform spatial grid, used for evaluating integrals of bound
 !  orbitals and densities numerically. 
 !
@@ -30,7 +33,9 @@
     public mol_grid
     public GridInitialize, GridDestroy, GridPointsBatch
     !
-    integer(ik), parameter     :: step_order = 3 ! There does not seem to be a good reason to change this one
+    integer(ik), parameter     :: step_order = 3      ! There does not seem to be a good reason to change this one
+    logical, parameter         :: randomize  = .true. ! Randomize orientation of the spherical shell; should give more
+                                                      ! accurate, but non-deterministic results
     !
     !  Radial grid type is used to cache integration points and weights on a
     !  [-1:1] grid. They'll be scaled as appropriate for each atom.
@@ -39,24 +44,69 @@
       real(rk), allocatable :: rw(:,:)  ! Grid positions (1,:) and weights (2,:)
     end type radial_grid
     !
+    type atom_grid
+      real(rk)    :: xyz(3)   ! Coordinates of the centres
+      real(rk)    :: rat      ! Parameter used for scaling the radial grid - eq. 25
+      integer(ik) :: nrad     ! Number of radial grid points per centre
+      integer(ik) :: nang     ! Number of points per angular shell
+    end type atom_grid
+    !
+    type ring_grid
+      real(rk)    :: rc(3)    ! ring centre
+      real(rk)    :: rn(3)    ! Normal; |ring_rn| = 1
+      real(rk)    :: rr       ! Radius of the ring
+      integer(ik) :: nphi     ! Number of elliptical slices (phi)
+      integer(ik) :: nrad     ! Number of points along "radial" coordinates (mu, nu)
+    end type ring_grid
+    !
+    type outer_grid
+      real(rk)    :: rc(3)    ! Coordinates of the centre of the outer grid
+      real(rk)    :: rout     ! Characteristic size of the outer grid
+      integer(ik) :: nrad     ! Number of radial grid points per centre
+      integer(ik) :: nang     ! Number of points per angular shell
+    end type outer_grid
+    !
     !  We may maintain multiple grids; as the result, all grid parameters must be collected in mol_grid type.
     !
     type mol_grid
       private
       !
-      !  Parameters defining the grid
+      !  Partition management; this part uses generic "partitions", which have to
+      !  be combined according to the Becke's blending formula to give the complete grid.
       !
-      integer(ik)                    :: natom         ! Number of integration centres
-      real(rk), allocatable          :: xyz(:,:)      ! Coordinates of the centres
-      real(rk), allocatable          :: rat(:)        ! Parameter used for scaling the radial grid - eq. 25
-      integer(ik), allocatable       :: nrad(:)       ! Number of radial grid points per centre
-      integer(ik), allocatable       :: nang(:)       ! Number of points per angular shell
+      integer(ik)                    :: npartitions   ! Number of partitions, what else?
+      character(len=10), allocatable :: p_type(:)     ! Partition types; the values currently can be:
+                                                      ! 'Atom'  - spherical partition, intended for atomic integration
+                                                      ! 'Ring'  - a toroidal partition, for integrating complex-coulomb operator
+                                                      ! 'Outer' - an outer-shell partition, for integrating CAPs
+      integer(ik), allocatable       :: p_shells(:)   ! Number of shells per partition; the actual definition of a shell
+                                                      ! is partition-specific
+      integer(ik), allocatable       :: p_shellsz(:)  ! Shell size within each partition (so we assume that partitions are made 
+                                                      ! of equally-sized shells)
+      integer(ik), allocatable       :: p_index(:)    ! Sequential number of each partition within it's partition-specific table
       !
-      !  Position of the next point batch within the grid. We always return an entire angular shell
+      !  Position of the next point batch within the grid. We always return an entire shell
       !
-      integer(ik), public            :: iatom
-      integer(ik)                    :: irad
-      !$ integer(OMP_LOCK_KIND)      :: update_lock   ! Lock must be acquired before modifying iatom, irad
+      integer(ik), public            :: next_part     ! Next partition to be processed; 1 to npartitions
+      integer(ik)                    :: next_shell    ! Next shell witin the partion; 1 to p_shells(next_part)
+      !$ integer(OMP_LOCK_KIND)      :: update_lock   ! Lock must be acquired before modifying nexr_part, next_shell
+      !
+      !  Spherical partitions, typically centered on atoms
+      !
+      integer(ik)                    :: natoms        ! Number of sphere-like centres
+      type (atom_grid), allocatable  :: atoms(:)      ! "atom" partitions - these are as described by Becke
+      !
+      !  Oblate spheroidal grids, needed for the ring singularity
+      !
+      integer(ik)                    :: nrings        ! Number of toroidal grids; currently must be 0 or 1
+      type (ring_grid), allocatable  :: rings(:)      ! "ring" partitions - needed for complex Coulomb continuation
+      !
+      !  Outer grids, needed for consistent integration in the outer region
+      !
+      integer(ik)                    :: nouter        ! Number of outer grids; must be 0 or 1. Can't be combined with a toroidal grid
+      type (outer_grid), allocatable :: outer(:)      ! "outer" partitions - needed for CAPs integration
+      !
+      !  Items below are used for caching quantities, which may be a little expensive to evaluate otherwise
       !
       type(radial_grid), allocatable :: radial(:)     ! Radial grid cache. Grid of order N is kept
                                                       ! at index N of radial(). Some (most) elements
@@ -67,19 +117,35 @@
     !
     !  Externally visible interfaces
     !
-    subroutine GridInitialize(grid,nrad,nang,xyz,types)
-      type(mol_grid), intent(out)   :: grid       ! Grid to initialize
-      integer(ik), intent(in)       :: nrad       ! Basic number of radial points; actual number of points 
-                                                  ! may depend on this value and atom types
-      integer(ik), intent(in)       :: nang       ! Number of angular points; can be 110, 302, or 770,
-                                                  ! giving the corresponding Lebedev's grid
-      real(rk), intent(in)          :: xyz(:,:)   ! Coordinates of centres, in Bohr
-      character(len=*), intent(in)  :: types(:)   ! Types of centres
+    subroutine GridInitialize(grid,nrad,nang,xyz,types, &
+                              ring,ring_rc,ring_rn,ring_nrad,ring_nphi, &
+                              outer,outer_rc,outer_rout,outer_nrad,outer_nang)
+      type(mol_grid), intent(out)       :: grid        ! Grid to initialize
+      integer(ik), intent(in)           :: nrad        ! Basic number of radial points; actual number of points 
+                                                       ! may depend on this value and atom types
+      integer(ik), intent(in)           :: nang        ! Number of angular points; can be 110, 302, or 770,
+                                                       ! giving the corresponding Lebedev's grid
+      real(rk), intent(in)              :: xyz(:,:)    ! Coordinates of centres, in Bohr
+      character(len=*), intent(in)      :: types(:)    ! Types of centres
+      ! Special-purpose grid parameters - ring singularity
+      logical, intent(in), optional     :: ring        ! Allow for the ring singularity; absense of ring is treated at ring=.false.
+      real(rk), intent(in), optional    :: ring_rc(3)  ! Centre of the ring
+      real(rk), intent(in), optional    :: ring_rn(3)  ! Normal direction to the ring plane; |rn| is the ring radius
+      integer(ik), intent(in), optional :: ring_nrad   ! Number of radial grid points in ring grid
+      integer(ik), intent(in), optional :: ring_nphi   ! Number of angular grid points in ring grid
+      ! Special-purpose grid parameters - outer sphere
+      logical, intent(in), optional     :: outer       ! Add outer-sphere grid; absense is treated as outer=.false.
+      real(rk), intent(in), optional    :: outer_rc(3) ! Coordinates of the grid centre
+      real(rk), intent(in), optional    :: outer_rout  ! Characteristic size
+      integer(ik), intent(in), optional :: outer_nrad  ! Number of radial points
+      integer(ik), intent(in), optional :: outer_nang  ! Number of angular points
       !
       integer(ik) :: alloc
       integer(ik) :: natom, iat, jat
       integer(ik) :: irad, rad_max
       real(rk)    :: rat, rij
+      integer(ik) :: nring, npart, ipart
+      integer(ik) :: nouter
       !
       call TimerStart('MolGrid Initialize')
       !
@@ -87,29 +153,15 @@
         stop 'molecular_grid%GridInitialize - bad input array sizes'
       end if
       !
+      !  Spherical partitions first
+      !
       natom = size(xyz,dim=2)
-      grid%natom = natom
-      allocate (grid%xyz(3,natom),grid%rat(natom),grid%nrad(natom),grid%nang(natom),stat=alloc)
+      grid%natoms   = natom
+      allocate (grid%atoms(natom),stat=alloc)
       if (alloc/=0) then
         write (out,"('Error ',i8,' allocating array for an ',i8,'-atom grid.')") alloc, natom
         stop 'molecular_grid%GridInitialize - out of memory (1)'
       end if
-      !
-      grid%xyz   = xyz
-      grid%nang  = nang  ! Checking will occur later
-      grid%nrad  = nrad  ! We'll modify later as appropriate
-      grid%rat   = 1._rk ! We'll modify later as appropriate
-      grid%iatom = 1_ik  ! Position the grid at the beginning
-      grid%irad  = 1_ik
-      !$ call omp_init_lock(grid%update_lock)
-      !
-      !  Fill atom sizes
-      !
-      scan_atom_types: do iat=1,natom
-        rat = AtomCovalentR(types(iat))   ! Returns radius in Angstrom; we use Bohr here
-        if (rat<=0) cycle scan_atom_types
-        grid%rat(iat) = 0.5_rk * rat / abohr
-      end do scan_atom_types
       !
       !  Check for collisions: this will cause problems with integrals!
       !
@@ -124,27 +176,152 @@
         end do
       end do collision_test
       !
+      !  Fill atom tables
+      !
+      scan_atom_types: do iat=1,natom
+        grid%atoms(iat)%xyz  = xyz(:,iat)
+        grid%atoms(iat)%nang = nang        ! Checking will occur later
+        grid%atoms(iat)%nrad = nrad        ! We'll modify later as appropriate
+        grid%atoms(iat)%rat  = 1._rk       ! We'll modify below as appropriate
+        rat = AtomCovalentR(types(iat))    ! Returns radius in Angstrom; we use Bohr here
+        if (rat<=0) cycle scan_atom_types
+        grid%atoms(iat)%rat  = 0.5_rk * rat / abohr
+      end do scan_atom_types
+      !
+      !  Now the toroidal grids, provided that they are present
+      !
+      nring = 0
+      if (present(ring)) then
+        if (ring) nring = 1
+      end if
+      grid%nrings = nring
+      allocate (grid%rings(nring),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('Error ',i8,' allocating array for an ',i8,'-ring grid.')") alloc, nring
+        stop 'molecular_grid%GridInitialize - out of memory (2)'
+      end if
+      if ( nring>0 ) then
+        if (.not.present(ring_rc) .or. .not.present(ring_rn) .or. &
+            .not.present(ring_nphi) .or. .not.present(ring_nrad)) then
+          stop 'molecular_grid%GridInitialize - missing ring parameters'
+        end if
+        grid%rings(1)%rc   = ring_rc
+        grid%rings(1)%rr   = sqrt(sum(ring_rn**2))
+        if (grid%rings(1)%rr<=0._rk) stop 'molecular_grid%GridInitialize - requested zero-radius ring?!'
+        grid%rings(1)%rn   = ring_rn / grid%rings(1)%rr
+        grid%rings(1)%nphi =  ring_nphi
+        grid%rings(1)%nrad =  ring_nrad
+        ! write (out,"('Added ring at rc = ',3f14.7)") grid%rings(1)%rc 
+        ! write (out,"('          Normal = ',3f14.7)") grid%rings(1)%rn 
+        ! write (out,"('          Radius = ', f14.7)") grid%rings(1)%rr
+      end if
+      !
+      !  Finally, the optional outer grid
+      !
+      nouter = 0
+      if (present(outer)) then
+        if (outer) nouter = 1
+      end if
+      grid%nouter = nouter
+      allocate (grid%outer(nouter),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('Error ',i8,' allocating array for an ',i8,'-sphere outer grid.')") alloc, nouter
+        stop 'molecular_grid%GridInitialize - out of memory (2a)'
+      end if
+      if ( nouter>0 ) then
+        if (.not.present(outer_rc)   .or. .not.present(outer_rout) .or. &
+            .not.present(outer_nrad) .or. .not.present(outer_nang)) then
+          stop 'molecular_grid%GridInitialize - missing outer grid parameters'
+        end if
+        grid%outer(1)%rc   = outer_rc
+        grid%outer(1)%rout = outer_rout
+        if (grid%outer(1)%rout<=0._rk) stop 'molecular_grid%GridInitialize - requested zero-size outer sphere?!'
+        grid%outer(1)%nrad = outer_nrad
+        grid%outer(1)%nang = outer_nang
+      end if
+      !
+      !  Either toroidal or outer grids can be present, but not both
+      !
+      if (grid%nrings+grid%nouter>1) stop 'molecular_grid%GridInitialize - can''t combine rings and outer-sphere partitions'
+      !
       !  Fill radial grid cache - recalculating radial grids on each call may
       !  be quite expensive!
       !
-      rad_max = maxval(grid%nrad)
+      rad_max = max(maxval(grid%atoms(:)%nrad),maxval(grid%rings(:)%nrad),maxval(grid%outer(:)%nrad))
       allocate (grid%radial(rad_max),stat=alloc)
       if (alloc/=0) then
         write (out,"('Error ',i8,' allocating radial grid cache. rad_max = ',i8)") alloc, rad_max
-        stop 'molecular_grid%GridInitialize - out of memory (2)'
+        stop 'molecular_grid%GridInitialize - out of memory (3)'
       end if
       !
-      fill_radial_cache: do iat=1,natom
-        irad = grid%nrad(iat)
-        if (allocated(grid%radial(irad)%rw)) cycle fill_radial_cache
+      fill_radial_cache_atoms: do iat=1,natom
+        irad = grid%atoms(iat)%nrad
+        call add_to_cache(irad)
+      end do fill_radial_cache_atoms
+      !
+      fill_radial_cache_rings: do iat=1,nring
+        irad = grid%rings(iat)%nrad
+        call add_to_cache(irad)
+      end do fill_radial_cache_rings
+      !
+      fill_radial_cache_outer: do iat=1,nouter
+        irad = grid%outer(iat)%nrad
+        call add_to_cache(irad)
+      end do fill_radial_cache_outer
+      !
+      !  Overall partition control - runs over all types of grid present
+      !
+      npart = grid%natoms + grid%nrings + grid%nouter
+      grid%npartitions = npart
+      allocate (grid%p_type(npart),grid%p_shells(npart),grid%p_shellsz(npart),grid%p_index(npart),stat=alloc)
+      if (alloc/=0) then
+        write (out,"('Error ',i8,' allocating array for an ',i8,'-element partition list.')") alloc, npart
+        stop 'molecular_grid%GridInitialize - out of memory (6)'
+      end if
+      !
+      ipart = 0
+      fill_atoms: do iat=1,grid%natoms
+        ipart = ipart + 1
+        grid%p_type   (ipart) = 'Atom'
+        grid%p_shells (ipart) = grid%atoms(iat)%nrad
+        grid%p_shellsz(ipart) = grid%atoms(iat)%nang
+        grid%p_index  (ipart) = iat
+      end do fill_atoms
+      !
+      fill_rings: do iat=1,grid%nrings
+        ipart = ipart + 1
+        grid%p_type   (ipart) = 'Ring'
+        grid%p_shells (ipart) = grid%rings(iat)%nphi
+        grid%p_shellsz(ipart) = grid%rings(iat)%nrad**2
+        grid%p_index  (ipart) = iat
+      end do fill_rings
+      !
+      fill_outer: do iat=1,grid%nouter
+        ipart = ipart + 1
+        grid%p_type   (ipart) = 'Outer'
+        grid%p_shells (ipart) = grid%outer(iat)%nrad
+        grid%p_shellsz(ipart) = grid%outer(iat)%nang
+        grid%p_index  (ipart) = iat
+      end do fill_outer
+      if (ipart/=grid%npartitions) stop 'molecular_grid%GridInitialize - count error'
+      !
+      grid%next_part  = 1
+      grid%next_shell = 1
+      !$ call omp_init_lock(grid%update_lock)
+      call TimerStop('MolGrid Initialize')
+      !
+      contains
+      subroutine add_to_cache(irad)
+        integer(ik), intent(in) :: irad
+        !
+        if (allocated(grid%radial(irad)%rw)) return
         allocate (grid%radial(irad)%rw(2,irad),stat=alloc)
         if (alloc/=0) then
           write (out,"('Error ',i8,' allocating radial grid ',i8)") alloc, irad
-          stop 'molecular_grid%GridInitialize - out of memory (3)'
+          stop 'molecular_grid%GridInitialize - out of memory (4)'
         end if
         call MathGetQuadrature('Legendre',irad,grid%radial(irad)%rw(1,:),grid%radial(irad)%rw(2,:))
-      end do fill_radial_cache
-      call TimerStop('MolGrid Initialize')
+      end subroutine add_to_cache
     end subroutine GridInitialize
     !
     subroutine GridDestroy(grid)
@@ -158,7 +335,11 @@
         deallocate (grid%radial(iord)%rw)
       end do free_radial_cache
       !
-      deallocate (grid%xyz,grid%rat,grid%nrad,grid%nang)
+      deallocate (grid%p_type,grid%p_shells,grid%p_shellsz,grid%p_index)
+      if (allocated(grid%atoms)) deallocate (grid%atoms)
+      if (allocated(grid%rings)) deallocate (grid%rings)
+      if (allocated(grid%outer)) deallocate (grid%outer)
+      !$ call omp_destroy_lock(grid%update_lock)
       call TimerStop('MolGrid Destroy')
     end subroutine GridDestroy
     !
@@ -166,14 +347,15 @@
       type(mol_grid), intent(inout)                  :: grid       ! Grid
       character(len=*), intent(in)                   :: action     ! What to do
 !     real(rk), pointer, intent(inout), optional     :: xyzw(:,:)  ! Next batch of points
-!    Declaration above causes Intel compiler 9.1 to barf at the invocation point of fill_grid_shell. Compiler bug?
+!    Declaration above causes Intel compiler 9.1 to barf at the invocation point of fill_spherical_grid_shell. Compiler bug?
       real(rk), pointer,                optional     :: xyzw(:,:)  ! Next batch of points
       integer(ik), intent(out), optional             :: count      ! Total number of batches
       logical, intent(out), optional                 :: done       ! Fill be set to .true. if out of points
       !
-      integer(ik) :: iatom, irad ! Local copies of iatom and irad; needed to avoid holding
-                                 ! a lock for too long.
-      integer(ik) :: nang        ! Size of the angular batch
+      integer(ik) :: ipart, ishell ! Local copies of next_part and next_shell; needed to avoid holding
+                                   ! a lock for too long.
+      integer(ik) :: iatom        
+      integer(ik) :: shellsz       ! Size of the points batch
       integer(ik) :: alloc       
       !
       call TimerStart('MolGrid PointsBatch')
@@ -183,17 +365,20 @@
           stop 'molecular_grid%GridPointsBatch - Bad action'
         case ('Batches count')
           if (.not.present(count)) stop 'molecular_grid%GridPointsBatch - required argument is missing (1)'
-          count = sum(grid%nrad)
+          count = sum(grid%p_shells)
         case ('Reset')
-          grid%iatom = 1_rk
-          grid%irad  = 1_rk
+          !$ call omp_set_lock(grid%update_lock)
+          grid%next_part  = 1
+          grid%next_shell = 1
+          !$omp flush
+          !$ call omp_unset_lock(grid%update_lock)
         case ('Next batch')
           if (.not.present(xyzw)) stop 'molecular_grid%GridPointsBatch - required argument is missing (2)'
           !$ call omp_set_lock(grid%update_lock)
           !$omp flush
-          iatom = grid%iatom
-          irad  = grid%irad
-          if (iatom>grid%natom) then
+          ipart  = grid%next_part
+          ishell = grid%next_shell
+          if (ipart>grid%npartitions) then
             if (present(done)) then
               done = .true.
             else
@@ -204,10 +389,10 @@
             call TimerStop('MolGrid PointsBatch')
             return
           end if
-          grid%irad = irad + 1
-          if (grid%irad > grid%nrad(iatom)) then
-            grid%irad  = 1
-            grid%iatom = iatom + 1
+          grid%next_shell = ishell + 1
+          if (grid%next_shell > grid%p_shells(ipart)) then
+            grid%next_shell = 1
+            grid%next_part  = ipart + 1
           end if
           !$omp flush
           !$ call omp_unset_lock(grid%update_lock)
@@ -215,31 +400,42 @@
           !  We are commited to a particular batch of points; the rest of this routine will not
           !  modify anything within the grid structure.
           !
-          nang = grid%nang(iatom)
+          shellsz = grid%p_shellsz(ipart)
           if (associated(xyzw)) then
-            if (size(xyzw,dim=2)/=nang) deallocate (xyzw)
+            if (size(xyzw,dim=2)/=shellsz) deallocate (xyzw)
           end if
           if (.not.associated(xyzw)) then
-            allocate (xyzw(4,nang),stat=alloc)
+            allocate (xyzw(4,shellsz),stat=alloc)
             if (alloc/=0) then
               write (out,"('molecular_grid%GridPointsBatch: Error ',i8,' allocating batch buffer for ',i8,' points')") &
-                     alloc, nang
+                     alloc, shellsz
               stop 'molecular_grid%GridPointsBatch - out of memory'
             end if
           end if
           !
           !  Done with all preliminaries, fill the grid points
           !
-          call fill_grid_shell(grid,iatom,irad,xyzw(:,:))
+          iatom = grid%p_index(ipart)
+          partition_type: select case (grid%p_type(ipart))
+            case default
+              stop 'molecular_grid%GridPointsBatch - unknown partition type '
+            case ('Atom')
+              call fill_spherical_grid_shell(grid,ipart,iatom,ishell,xyzw(:,:))
+            case ('Ring')
+              call fill_toroidal_grid_shell (grid,ipart,iatom,ishell,xyzw(:,:))
+            case ('Outer')
+              call fill_outer_grid_shell    (grid,ipart,iatom,ishell,xyzw(:,:))
+          end select partition_type
       end select batch_case
       call TimerStop('MolGrid PointsBatch')
     end subroutine GridPointsBatch
     !
     !  Internal routines beyond this point
     !
-    subroutine fill_grid_shell(grid,iatom,irad,xyzw)
+    subroutine fill_spherical_grid_shell(grid,ipart,iatom,irad,xyzw)
       type(mol_grid), intent(in) :: grid      ! Everything we want to know about the grid
-      integer(ik), intent(in)    :: iatom     ! Atom index; ignore data within the structure
+      integer(ik), intent(in)    :: ipart     ! Partition index
+      integer(ik), intent(in)    :: iatom     ! Atom index; this is the same as grid%p_index(ipart)
       integer(ik), intent(in)    :: irad      ! Radial index; ditto
       real(rk), intent(out)      :: xyzw(:,:) ! Grid positions and weights
       !
@@ -254,11 +450,13 @@
       real(rk)          :: r_mid         ! Characteristic radius of the atom
       real(rk), pointer :: ang_xyzw(:,:) ! Our angular grid
       real(rk)          :: p_wgt         ! Becke partitioning weight
+      real(rk)          :: euler(3)      ! Random Euler angles
+      real(rk)          :: rm(3,3)       ! Randomized rotation matrix
       !
-      nrad  = grid%nrad(iatom)
-      nang  = grid%nang(iatom)
-      rc    = grid%xyz(:,iatom)
-      r_mid = grid%rat(iatom)
+      nrad  = grid%atoms(iatom)%nrad
+      nang  = grid%atoms(iatom)%nang
+      rc    = grid%atoms(iatom)%xyz(:)
+      r_mid = grid%atoms(iatom)%rat
       rad   = grid%radial(nrad)%rw(1,irad) ! Unscaled grid position, [-1:+1] range
       w_rad = grid%radial(nrad)%rw(2,irad)
       !
@@ -280,57 +478,236 @@
       !
       select case (nang)
         case default
-          write (out,"('molecular_grid%fill_grid_shell: Angular grid ',i6,' is not recognized.')") nang
-          stop 'molecular_grid%fill_grid_shell - bad angular grid'
+          write (out,"('molecular_grid%fill_spherical_grid_shell: Angular grid ',i6,' is not recognized.')") nang
+          stop 'molecular_grid%fill_spherical_grid_shell - bad angular grid'
         case (110) ; ang_xyzw => lebedev_gr17
         case (302) ; ang_xyzw => lebedev_gr29
         case (770) ; ang_xyzw => lebedev_gr47
       end select
       !
+      !  Randomize shell orientation, to prevent accumulation or errors
+      !
+      if (randomize) then
+        call random_number(euler)
+        euler = twopi * euler
+        call MathRotationMatrix(euler,rm)
+      else
+        call MathSetUnitMatrix(rm)
+      end if
+      !
       !  Figure out coordinates and weights of atomic grid points in this shell
       !
-      xyzw(1:3,:) = spread(rc,dim=2,ncopies=nang) + rad * ang_xyzw(1:3,:)
+      xyzw(1:3,:) = spread(rc,dim=2,ncopies=nang) + rad * matmul(rm,ang_xyzw(1:3,:))
       xyzw(  4,:) = w_rad * ang_xyzw(4,:)
       !
       !  Magic sauce: Becke's partitioning weights
       !
       partitioning_weights: do iang=1,nang
-        p_wgt        = partitioning_weight(grid,iatom,xyzw(1:3,iang))
+        p_wgt        = partitioning_weight(grid,ipart,xyzw(1:3,iang))
         xyzw(4,iang) = p_wgt * xyzw(4,iang)
       end do partitioning_weights
-    end subroutine fill_grid_shell
+      !*????
+      ! write (out,"(('0',4(1x,g20.12)))") xyzw
+    end subroutine fill_spherical_grid_shell
+    !
+    !  Oblate spheroidal grid
+    !
+    subroutine fill_toroidal_grid_shell(grid,ipart,iring,iphi,xyzw)
+      type(mol_grid), intent(in) :: grid      ! Everything we want to know about the grid
+      integer(ik), intent(in)    :: ipart     ! Partition index
+      integer(ik), intent(in)    :: iring     ! Ring index; this is the same as grid%p_index(ipart)
+      integer(ik), intent(in)    :: iphi      ! Angular index [along phi]
+      real(rk), intent(out)      :: xyzw(:,:) ! Grid positions and weights
+      !
+      !  Step one: fill grid positions and unscaled weights.
+      !
+      real(rk)              :: rc(3)       ! Center of the ring sphere
+      real(rk)              :: rn(3)       ! Normal of the ring
+      real(rk)              :: rr          ! Radius of the ring
+      integer(ik)           :: nphi        ! Number of elliptical slices (phi) - uniform grid
+      integer(ik)           :: nrad        ! Number of points along "radial" coordinates (mu, nu)
+      real(rk)              :: p_wgt       ! Becke partitioning weight
+      real(rk), allocatable :: g_mu(:,:)   ! Grid positions and weights; mu grid [0:inf)
+      integer(ik)           :: alloc
+      integer(ik)           :: imu, inu    ! Grid sub-indices
+      integer(ik)           :: igrid       ! Composite index
+      real(rk)              :: mu, nu, phi ! Oblate spheroidal coordinates
+      real(rk)              :: rm(3,3)     ! Rotation matrix for turning the toroid to the desired orientation
+      !
+      rc   = grid%rings(iring)%rc
+      rn   = grid%rings(iring)%rn
+      rr   = grid%rings(iring)%rr
+      nphi = grid%rings(iring)%nphi
+      nrad = grid%rings(iring)%nrad
+      !
+      !  The nu and phi grids are equallt spaced; the mu grid, however, requires a bit of
+      !  more careful handling.
+      !
+      allocate (g_mu(2,nrad),stat=alloc)
+      if (alloc/=0) stop 'molecular_grid%fill_toroidal_grid_shell - out of memory'
+      g_mu = grid%radial(nrad)%rw
+      !
+      !  Scale nu grid position and weight. Since the distance from the origin
+      !  grows exponentially with mu, we'll use:
+      !
+      !    Log[1+Pi*(1+x)/(1-x)]
+      !
+      !  The weight gets scaled by the derivative of the transformation function,
+      !  which is:
+      !
+      !    2*Pi/((x-1)(Pi+1+(Pi-1)*x))
+      !
+      g_mu(2,:) = g_mu(2,:)*twopi/((1-g_mu(1,:))*(pi+1+(pi-1)*(g_mu(1,:))))
+      g_mu(1,:) = log(1+pi*(1+g_mu(1,:))/(1-g_mu(1,:)))
+      !
+      !  Construct the product grid of (mu,nu), in the standard orientation
+      !  and at the origin.
+      !
+      phi   = pi * real(2*iphi-nphi-1,kind=rk) / nphi
+      igrid = 0
+      fill_grid_nu: do inu=1,nrad
+        nu = 0.5_rk * pi * real(2*inu-nrad-1,kind=rk) / nrad
+        fill_grid_mu: do imu=1,nrad
+          mu = g_mu(1,imu)
+          igrid = igrid + 1
+          xyzw(1,igrid) = rr * cosh(mu) * cos(nu) * cos(phi)
+          xyzw(2,igrid) = rr * cosh(mu) * cos(nu) * sin(phi)
+          xyzw(3,igrid) = rr * sinh(mu) * sin(nu)
+          xyzw(4,igrid) = rr**3 * cosh(mu) * cos(nu) * (sinh(mu)**2 + sin(nu)**2) &
+                        * g_mu(2,imu) * (pi/nrad) * (twopi/nphi)
+        end do fill_grid_mu
+      end do fill_grid_nu
+      if (igrid/=size(xyzw,dim=2)) stop 'molecular_grid%fill_toroidal_grid_shell - count error'
+      !
+      !  Translate and rotate the shell to the desired position
+      !
+      call MathRotationMatrix((/0._rk,-acos(rn(3)),-atan2(rn(2),rn(1))/),rm)
+      ! write (out,*) ' rn = ', rn
+      ! write (out,*) ' xx = ', matmul(rm,(/0._rk,0._rk,1._rk/))
+      move_grid: do igrid=1,size(xyzw,dim=2)
+        xyzw(1:3,igrid) = rc + matmul(rm,xyzw(1:3,igrid))
+      end do move_grid
+      !
+      !  Magic sauce: Becke's partitioning weights
+      !
+      partitioning_weights: do igrid=1,size(xyzw,dim=2)
+        p_wgt         = partitioning_weight(grid,ipart,xyzw(1:3,igrid))
+        xyzw(4,igrid) = p_wgt * xyzw(4,igrid)
+      end do partitioning_weights
+      !* ????
+      ! write (out,"(('1',4(1x,g20.12)))") xyzw
+    end subroutine fill_toroidal_grid_shell
+    !
+    subroutine fill_outer_grid_shell(grid,ipart,isphere,irad,xyzw)
+      type(mol_grid), intent(in) :: grid      ! Everything we want to know about the grid
+      integer(ik), intent(in)    :: ipart     ! Partition index
+      integer(ik), intent(in)    :: isphere   ! Outer sphere index; this is the same as grid%p_index(ipart)
+      integer(ik), intent(in)    :: irad      ! Radial index; ditto
+      real(rk), intent(out)      :: xyzw(:,:) ! Grid positions and weights
+      !
+      !  Step one: fill grid positions and unscaled weights.
+      !
+      integer(ik)       :: nrad          ! Number of radial points 
+      integer(ik)       :: nang          ! Number of angular points 
+      integer(ik)       :: iang
+      real(rk)          :: rc(3)         ! Center of the sphere
+      real(rk)          :: rad           ! Radius of the current sphere
+      real(rk)          :: w_rad         ! Integration weight associated with the radial point
+      real(rk)          :: r_mid         ! Characteristic radius of the grid
+      real(rk), pointer :: ang_xyzw(:,:) ! Our angular grid
+      real(rk)          :: p_wgt         ! Becke partitioning weight
+      real(rk)          :: euler(3)      ! Random Euler angles
+      real(rk)          :: rm(3,3)       ! Randomized rotation matrix
+      !
+      nrad  = grid%outer(isphere)%nrad
+      nang  = grid%outer(isphere)%nang
+      rc    = grid%outer(isphere)%rc(:)
+      r_mid = grid%outer(isphere)%rout
+      rad   = grid%radial(nrad)%rw(1,irad) ! Unscaled grid position, [-1:+1] range
+      w_rad = grid%radial(nrad)%rw(2,irad)
+      !
+      !  Scale grid position and weight. We'll use Becke's scaling function:
+      !    r_mid * (1+x)/(1-x)
+      !  The weight gets scaled by the derivative of the transformation function,
+      !  which is:
+      !    r_mid * 2/(1-x)**2
+      !
+      w_rad = w_rad * r_mid * 2._rk / (1-rad)**2
+      rad   = r_mid * (1+rad)/(1-rad)
+      !
+      !  Scale weight by the spherical volume element, since our angular grid 
+      !  is normalized to unity
+      !
+      w_rad = w_rad * 4._rk * pi * rad**2
+      !
+      !  Choose angular grid
+      !
+      select case (nang)
+        case default
+          write (out,"('molecular_grid%fill_outer_grid_shell: Angular grid ',i6,' is not recognized.')") nang
+          stop 'molecular_grid%fill_outer_grid_shell - bad angular grid'
+        case (110) ; ang_xyzw => lebedev_gr17
+        case (302) ; ang_xyzw => lebedev_gr29
+        case (770) ; ang_xyzw => lebedev_gr47
+      end select
+      !
+      !  Randomize shell orientation, to prevent accumulation or errors
+      !
+      if (randomize) then
+        call random_number(euler)
+        euler = twopi * euler
+        call MathRotationMatrix(euler,rm)
+      else
+        call MathSetUnitMatrix(rm)
+      end if
+      !
+      !  Figure out coordinates and weights of atomic grid points in this shell
+      !
+      xyzw(1:3,:) = spread(rc,dim=2,ncopies=nang) + rad * matmul(rm,ang_xyzw(1:3,:))
+      xyzw(  4,:) = w_rad * ang_xyzw(4,:)
+      !
+      !  Magic sauce: Becke's partitioning weights
+      !
+      partitioning_weights: do iang=1,nang
+        p_wgt        = partitioning_weight(grid,ipart,xyzw(1:3,iang))
+        xyzw(4,iang) = p_wgt * xyzw(4,iang)
+      end do partitioning_weights
+      !*????
+      ! write (out,"(('0',4(1x,g20.12)))") xyzw
+    end subroutine fill_outer_grid_shell
     !
     !  Calculate Becke's partitioning weight for a grid point
     !
-    function partitioning_weight(grid,iatom,xyz) result(w)
+    function partitioning_weight(grid,ipart,xyz) result(w)
       type(mol_grid), intent(in) :: grid
-      integer(ik), intent(in)    :: iatom  ! Parent atom
+      integer(ik), intent(in)    :: ipart  ! Parent partition
       real(rk), intent(in)       :: xyz(:) ! Grid point
       real(rk)                   :: w      ! Partitioning weight
       !
       real(rk)    :: w_tot
-      integer(ik) :: jatom
+      integer(ik) :: jpart
       !
-      w     = raw_weight(grid,iatom,xyz)
+      w     = raw_weight(grid,ipart,xyz)
       w_tot = w
-      all_claims: do jatom=1,grid%natom
-        if (jatom==iatom) cycle all_claims
-        w_tot = w_tot + raw_weight(grid,jatom,xyz)
+      all_claims: do jpart=1,grid%npartitions
+        if (jpart==ipart) cycle all_claims
+        w_tot = w_tot + raw_weight(grid,jpart,xyz)
       end do all_claims
       w = w / w_tot
     end function partitioning_weight
     !
     !  Calculate Becke's primitive cell weight
     !
-    function raw_weight(grid,iatom,xyz) result(w)
+    function raw_weight(grid,ipart,xyz) result(w)
       type(mol_grid), intent(in) :: grid
-      integer(ik), intent(in)    :: iatom  ! Parent atom
+      integer(ik), intent(in)    :: ipart  ! Parent partition
       real(rk), intent(in)       :: xyz(:) ! Grid point
       real(rk)                   :: w      ! Partitioning weight
       !
-      integer(ik) :: jatom
-      real(rk)    :: ri, rj   ! Distance from grid point to atoms I and J
-      real(rk)    :: rij      ! Distance between atoms I and J
+      integer(ik) :: jpart
+      integer(ik) :: iatom, jatom
+      real(rk)    :: ri, rj   ! Distance from grid point to partitions I and J
+      real(rk)    :: rij      ! Distance between partitions I and J
       real(rk)    :: muij     ! Elliptical distance difference coordinate
       real(rk)    :: nuij     ! "Adjusted" cell boundary
       real(rk)    :: aij      ! Adjustment parameter
@@ -338,26 +715,191 @@
       real(rk)    :: uij      ! 
       real(rk)    :: sf
       !
-      ri = sqrt(sum( (xyz-grid%xyz(:,iatom))**2 ))
+      iatom = grid%p_index(ipart)
+      ri = distance_point_to_partition(grid,ipart,xyz)
       w = 1.0_rk
-      cell_accumulate: do jatom=1,grid%natom
-        if (jatom==iatom) cycle cell_accumulate
-        rj   = sqrt(sum( (              xyz-grid%xyz(:,jatom))**2 ))
-        rij  = sqrt(sum( (grid%xyz(:,iatom)-grid%xyz(:,jatom))**2 ))
-        muij = (ri-rj)/rij
+      cell_accumulate: do jpart=1,grid%npartitions
+        if (jpart==ipart) cycle cell_accumulate
+        jatom = grid%p_index(jpart)
+        rj    = distance_point_to_partition(grid,jpart,xyz)
+        rij   = distance_partition_to_partition(grid,ipart,jpart,xyz)
+        muij  = (ri-rj)/rij
         !
         !  "Adjust" the cell boundary to account for heteronuclear bonding - Becke's appendix A
+        !  The adjustment is only applicable if both cells are atoms!
         !
-        chi  = grid%rat(iatom)/grid%rat(jatom)
-        uij  = (chi-1._rk)/(chi+1._rk)
-        aij  = uij/(uij**2-1._rk)
-        aij  = min(0.5_rk,max(-0.5_rk,aij))
+        if (grid%p_type(ipart)=='Atom' .and. grid%p_type(jpart)=='Atom') then
+          chi  = grid%atoms(iatom)%rat/grid%atoms(jatom)%rat
+          uij  = (chi-1._rk)/(chi+1._rk)
+          aij  = uij/(uij**2-1._rk)
+          aij  = min(0.5_rk,max(-0.5_rk,aij))
+        else
+          aij  = 0._rk
+        end if
         !
         nuij = muij + aij * (1._rk-muij**2)
-        sf   = step_function(muij)
+      ! sf   = step_function(muij)           !???? This was my original code; it looks like a bug!
+        sf   = step_function(nuij)
         w    = w * sf
       end do cell_accumulate
     end function raw_weight
+    !
+    function distance_point_to_partition(grid,ipart,xyz) result(ri)
+      type(mol_grid), intent(in) :: grid 
+      integer(ik), intent(in)    :: ipart
+      real(rk), intent(in)       :: xyz(:)  ! Point for which we need the distance
+      real(rk)                   :: ri
+      !
+      integer(ik) :: iatom
+      !
+      iatom = grid%p_index(ipart)
+      select case (grid%p_type(ipart))
+        case default
+          stop 'molecular_grid%distance_point_to_partition - unknown partion type'
+        case ('Atom')  
+          ri = sqrt(sum( (xyz-grid%atoms(iatom)%xyz)**2 ))
+        case ('Ring')
+          ri = pt_ring(xyz,grid%rings(iatom))
+        case ('Outer')
+          ri = abs(sqrt(sum((xyz-grid%outer(iatom)%rc)**2))-grid%outer(iatom)%rout)
+       end select
+    end function distance_point_to_partition
+    !
+    function distance_partition_to_partition(grid,ipart,jpart,xyz) result(rij)
+      type(mol_grid), intent(in) :: grid 
+      integer(ik), intent(in)    :: ipart  ! Partitions we need the distance between
+      integer(ik), intent(in)    :: jpart
+      real(rk), intent(in)       :: xyz(:) ! Point we are looking at; it may affect the partition-partition distance
+      real(rk)                   :: rij
+      !
+      integer(ik) :: iatom, jatom
+      !
+      iatom = grid%p_index(ipart)
+      jatom = grid%p_index(jpart)
+      select case (trim(grid%p_type(ipart))//' '//trim(grid%p_type(jpart)))
+        case default
+          stop 'molecular_grid%distance_partition_to_partition - unknown partion type combination'
+        case ('Atom Atom')  
+          rij = sqrt(sum( (grid%atoms(jatom)%xyz-grid%atoms(iatom)%xyz)**2 ))
+        case ('Atom Ring')
+          rij = sphere_ring(xyz,grid%rings(jatom),grid%atoms(iatom)%xyz)
+        case ('Ring Atom')
+          rij = sphere_ring(xyz,grid%rings(iatom),grid%atoms(jatom)%xyz)
+        case ('Atom Outer')
+          rij = sphere_outer(xyz,grid%outer(jatom),grid%atoms(iatom)%xyz)
+        case ('Outer Atom')
+          rij = sphere_outer(xyz,grid%outer(iatom),grid%atoms(jatom)%xyz)
+      end select
+    end function distance_partition_to_partition
+    !
+    !  Distance from a point to the nearest point on a ring
+    !
+    function pt_ring(xyz,ring) result (ri)
+      real(rk), intent(in)        :: xyz(:)
+      type(ring_grid), intent(in) :: ring
+      real(rk)                    :: ri
+      !
+      real(rk) :: r12(3)   ! Vector from the centre of the ring to the point
+      real(rk) :: rn (3)   ! Projection of r12 to ring normal
+      real(rk) :: rp (3)   ! r12 - rn
+      real(rk) :: lrn, lrp ! Lengths of rn and rp
+      !
+      r12 = xyz - ring%rc
+      rn  = ring%rn * sum(ring%rn*r12)
+      rp  = r12 - rn
+      lrn = sqrt(sum(rn**2))
+      lrp = sqrt(sum(rp**2))
+      ri  = sqrt(lrn**2 + (lrp-ring%rr)**2)
+    end function pt_ring
+    !
+    !  Distance from a centre to the point on a ring nearest to a given point
+    !
+    function sphere_ring(xyz,ring,sph_xyz) result (ri)
+      real(rk), intent(in)        :: xyz(:)      ! Grid point
+      type(ring_grid), intent(in) :: ring        ! Ring
+      real(rk), intent(in)        :: sph_xyz(:)  ! Sphere centre
+      real(rk)                    :: ri
+      !
+      real(rk) :: tmp_xyz(3) ! Fallback for direction choice
+      real(rk) :: rim(3)     ! Point on the ring; set by get_rim_direction()
+      !
+      if (.not.get_rim_direction(xyz)) then
+        !
+        !  Grid point is on-axis; try to choose direction towards the sphere centre
+        !
+        if (.not.get_rim_direction(sph_xyz)) then
+          !
+          !  Sphere centre is on-axis as well; choose direction towards smallest 
+          !  component of ring%rn
+          !
+          tmp_xyz = 0
+          tmp_xyz(minloc(ring%rn,dim=1)) = 1._rk
+          if (.not.get_rim_direction(tmp_xyz)) then
+            stop 'molecular_grid%sphere_ring - an impossible stop reached'
+          end if
+        end if
+      end if
+      !
+      ri  = sqrt(sum((sph_xyz-rim)**2))
+      !
+      contains 
+      function get_rim_direction(pt_xyz) result(happy)
+        real(rk), intent(in) :: pt_xyz(:) ! Point which defines the required rim direction
+        real(rk)             :: r12(3)    ! Vector from the centre of the ring to the point
+        real(rk)             :: rn (3)    ! Projection of r12 to ring normal
+        real(rk)             :: rp (3)    ! r12 - rn
+        real(rk)             :: lrp       ! Lengths of rn and rp
+        logical              :: happy     ! Set to .true. if rim direction found
+        !
+        r12 = pt_xyz - ring%rc
+        rn  = ring%rn * sum(ring%rn*r12)
+        rp  = r12 - rn
+        lrp = sqrt(sum(rp**2))
+        if (lrp>=spacing(1e3_rk*ring%rr)) then
+          rim   = ring%rc + rp * (ring%rr/lrp)
+          happy = .true.
+        else
+          happy = .false.
+        end if
+      end function get_rim_direction
+    end function sphere_ring
+    !
+    !  Distance from a centre to the point on a sphere nearest to a given point
+    !
+    function sphere_outer(xyz,outer,sph_xyz) result (ri)
+      real(rk), intent(in)         :: xyz(:)      ! Grid point
+      type(outer_grid), intent(in) :: outer       ! Outer sphere
+      real(rk), intent(in)         :: sph_xyz(:)  ! Atomic sphere centre
+      real(rk)                     :: ri
+      !
+      real(rk) :: rel_xyz(3) ! Position of the grid point relative to the outer sphere
+      real(rk) :: rrel       ! Length of rel_xyz(:)
+      real(rk) :: rim(3)     ! Point on the sphere
+      !
+      !  try to find direction from centre of the outer sphere towards the grid point
+      !
+      rel_xyz = xyz - outer%rc
+      rrel    = sqrt(sum(rel_xyz**2))
+      if (rrel>spacing(1e4_rk*outer%rout)) then
+        rel_xyz = rel_xyz / rrel
+      else
+        !
+        !  grid point is very close to the center of the outer sphere; chose direction towards the atomic sphere
+        !
+        rel_xyz = sph_xyz - outer%rc
+        rrel    = sqrt(sum(rel_xyz**2))
+        if (rrel>spacing(1e4_rk*outer%rout)) then
+          rel_xyz = rel_xyz / rrel
+        else
+          !
+          !  atomic sphere is also very close to the outer sphere; then it does not matter what we choose
+          !
+          rel_xyz = (/ 0, 0, 1 /)
+        end if
+      end if
+      rim = outer%rc + outer%rout * rel_xyz
+      ri  = sqrt(sum((sph_xyz-rim)**2))
+    end function sphere_outer
     !
     function step_function(mu) result(sf)
       real(rk), intent(in)    :: mu

--- a/nat_ibo.f90
+++ b/nat_ibo.f90
@@ -31,7 +31,7 @@ program ibocalc
     call accuracyInitialize
 
     ofile = 10
-    extbas = '/globalhome/rymac/Projects/PartialCharge/extbas'
+    extbas = '/globalhome/rymac/Projects/PartialCharge/partdens/atomlib/extbas'
 
     localize_virt = .false.
     pwr = 2

--- a/timer.f90
+++ b/timer.f90
@@ -1,10 +1,10 @@
 module timer
 !
 !  Timing routines. Because of the possibility for parallel
-!  execution, potentially on two scales at the same time 
+!  execution, potentially on two scales at the same time
 !  (OpenMP and MPI), all timings are done using real time.
 !
-!  For OpenMP programs, all calls to timer routines from 
+!  For OpenMP programs, all calls to timer routines from
 !  secondary threads are silently ignored.
 !
 !  The externally visible routines are:
@@ -15,9 +15,9 @@ module timer
 !
 !  Internally, timers are implemented using a hash table and
 !  should have constant cost regardless of the number of
-!  timers. Hash implementation follows Algorthim L (linear 
-!  insertion with linear search) of chapter 6.4 of Knuth's 
-!  vol 3. Hash function is taken from Aho, Sethi, and Ullman, 
+!  timers. Hash implementation follows Algorthim L (linear
+!  insertion with linear search) of chapter 6.4 of Knuth's
+!  vol 3. Hash function is taken from Aho, Sethi, and Ullman,
 !  pp. 434-438. Because timers are persistent, there is no
 !  deletion.
 !
@@ -65,7 +65,7 @@ module timer
   !  Public interfaces
   !
     !
-    !  Start timing region. 
+    !  Start timing region.
     !
     subroutine TimerStart(region)
       character(len=*), intent(in) :: region  ! Timer name
@@ -102,7 +102,7 @@ module timer
       t%cpu_start  = get_cpu_time ()
     end subroutine TimerStart
     !
-    !  End timing region. 
+    !  End timing region.
     !
     subroutine TimerStop(region)
       character(len=*), intent(in) :: region  ! Timer name
@@ -161,8 +161,8 @@ module timer
     !
     subroutine TimerReport
       real(trk)          :: real_now
-      real(trk)          :: cpu_now 
-      real(trk)          :: real_time, cpu_time 
+      real(trk)          :: cpu_now
+      real(trk)          :: real_time, cpu_time
       real(trk)          :: real_kids, cpu_kids
       real(trk)          :: real_threshold
       real(trk)          :: cpu_threshold
@@ -207,14 +207,14 @@ module timer
         end if
         !
         ! Calculate active-timer corrections
-        ! 
+        !
         real_time = 0 ; real_kids = 0 ;
         cpu_time  = 0 ; cpu_kids  = 0 ;
         active     = ' '
         if (t%active) then
           real_time = real_now - t%real_start
           cpu_time  = cpu_now  - t%cpu_start
-          if (t_active/=t%stack_p) then 
+          if (t_active/=t%stack_p) then
             !
             ! If we are not at the top of the stack, adjust
             ! cumulative children time.
@@ -276,7 +276,7 @@ module timer
     !  so this code gets a little messy to handle the roll-over.
     !
     !  Furthermore, we have to make sure that get_real_time() is
-    !  time-ordered; anything else will play havoc with timing 
+    !  time-ordered; anything else will play havoc with timing
     !  routines.
     !
     function get_real_time() result(t)
@@ -408,7 +408,7 @@ module timer
       character(len=*), intent(in) :: str
 !
       integer :: i, chr, g
-      integer :: mask 
+      integer :: mask
       data mask/Z"1FFFFFF"/
 !
 !    This hash assumes at least 29-bit integers. It is supposedly

--- a/timer.f90
+++ b/timer.f90
@@ -26,9 +26,9 @@ module timer
   private
   public TimerStart, TimerStop, TimerReport
 !
-  integer, parameter :: trk        = selected_real_kind(14)
-  integer, parameter :: table_size = 1000 ! Max number of entries to track
-  integer, parameter :: name_len   =   40 ! Max length of timer name
+  integer, parameter     :: trk        = selected_real_kind(14)  ! Must be of default integer kind
+  integer(ik), parameter :: table_size = 1000 ! Max number of entries to track
+  integer(ik), parameter :: name_len   =   40 ! Max length of timer name
 !
   type tim
     logical                 :: used       ! Slot used?
@@ -258,13 +258,14 @@ module timer
         if (count_bad_cpu >0) write (out,"(t5,'  CPU-time ordering violations = ',f16.0)") count_bad_cpu
       end if
       write (out,"()")
+      call flush(out)
     end subroutine TimerReport
   !
   !  Support routines
   !
     logical function omp_secondary()
     !$ use OMP_LIB
-      integer :: this_thread
+      integer :: this_thread  ! Must be of default integer kind
       !
       this_thread = 0
       !$ this_thread = omp_get_thread_num()
@@ -281,9 +282,9 @@ module timer
     function get_real_time() result(t)
       real(trk) :: t
       !
-      integer         :: count, count_rate, count_max
+      integer         :: count, count_rate, count_max ! Must be of default integer kind
       real(trk), save :: overflow   =  0
-      integer, save   :: last_count = -1
+      integer, save   :: last_count = -1   ! Must be of default integer kind
       real(trk), save :: last_time  = -1   ! Initialize to an impossible small value
       !
       call system_clock(count,count_rate,count_max)
@@ -399,6 +400,9 @@ module timer
       end do search
       !
     end function insert_item
+    !
+    !  Function below must use at least 29-bit integers. We'll stick
+    !  to the default kind.
     !
     integer function string_hash(str) result(h)
       character(len=*), intent(in) :: str


### PR DESCRIPTION
All multigrid scripts have been updated to later versions. This fixes issues with Becke grids not depending on atom type.

Some notes about the updates:

- The mol_grid property `next_part` is assumed to be equal to the atomic coefficient, which is not true if other grid types are present
- The molecular_grid library has an option to randomize grid angles, which might be useful for removing grid bias from QTAIM calculations